### PR TITLE
Improve payment visibility and Jalali formatting

### DIFF
--- a/management/serializers.py
+++ b/management/serializers.py
@@ -18,11 +18,24 @@ class PaymentSerializer(serializers.ModelSerializer):
     """
     # نمایش نام دانش‌آموز به جای آیدی
     student_name = serializers.CharField(source='student.profile.get_full_name', read_only=True)
+    status_display = serializers.CharField(source='get_status_display', read_only=True)
 
     class Meta:
         model = Payment
-        fields = ['id', 'student', 'student_name', 'course', 'amount', 'reference_number', 'payment_date', 'status', 'created_at', 'admin_notes']
-        read_only_fields = ['student_name', 'created_at']
+        fields = [
+            'id',
+            'student',
+            'student_name',
+            'course',
+            'amount',
+            'reference_number',
+            'payment_date',
+            'status',
+            'status_display',
+            'created_at',
+            'admin_notes',
+        ]
+        read_only_fields = ['student_name', 'status_display', 'created_at']
 
 
 class ChatMessageSerializer(serializers.ModelSerializer):

--- a/management/url.py
+++ b/management/url.py
@@ -1,8 +1,8 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import (ConversationListView, MessageListView,
-                    NotificationSendView, PaymentSubmissionView,
-                    PaymentViewSet)
+                    NotificationSendView, PaymentStatusView,
+                    PaymentSubmissionView, PaymentViewSet)
 
 # ساخت یک روتر برای ViewSet ها
 router = DefaultRouter()
@@ -17,6 +17,7 @@ urlpatterns = [
     path('chat/conversations/', ConversationListView.as_view(), name='conversation-list'),
     path('chat/messages/<int:user_id>/', MessageListView.as_view(), name='message-list'),
     path('payments/submit/', PaymentSubmissionView.as_view(), name='payment-submit'),
+    path('payments/mine/', PaymentStatusView.as_view(), name='payment-status'),
     path('notifications/send/', NotificationSendView.as_view(), name='notification-send'),
 ]
 

--- a/plans/templates/plans/management.html
+++ b/plans/templates/plans/management.html
@@ -84,9 +84,32 @@
             background-color: #4f46e5;
             color: white;
         }
+        .toast-message {
+            direction: rtl;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.75rem 1rem;
+            border-radius: 0.75rem;
+            box-shadow: 0 10px 15px -3px rgb(15 23 42 / 0.25);
+            color: #fff;
+            animation: fadeIn 0.2s ease-out;
+            font-size: 0.875rem;
+        }
+        .toast-message.success {
+            background: linear-gradient(135deg, #16a34a, #22c55e);
+        }
+        .toast-message.error {
+            background: linear-gradient(135deg, #dc2626, #ef4444);
+        }
+        .toast-message.info {
+            background: linear-gradient(135deg, #2563eb, #4f46e5);
+        }
     </style>
 </head>
 <body class="w-full h-screen">
+
+    <div id="toast-container" class="fixed top-6 right-6 flex flex-col gap-3 z-50"></div>
 
     <!-- Header -->
     <header class="bg-white shadow-md p-3 flex justify-between items-center z-20 shrink-0">
@@ -226,11 +249,13 @@
                 <div><label class="block text-sm font-medium text-gray-700">مبلغ واریز شده (تومان)</label><input name="amount" type="number" min="0" step="1000" required class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"></div>
                 <div><label class="block text-sm font-medium text-gray-700">شماره پیگیری / ارجاع</label><input name="reference_number" type="text" required class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"></div>
                 <div><label class="block text-sm font-medium text-gray-700">تاریخ واریز</label><input name="payment_date" type="date" required class="mt-1 block w-full border border-gray-300 rounded-md shadow-sm p-2"></div>
-                <div class="text-left pt-4">
+                <div class="flex items-center justify-between pt-4 gap-3">
                     <button type="button" data-close-modal="payment-modal" class="px-4 py-2 bg-gray-200 rounded-lg">انصراف</button>
-                    <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-lg">ارسال برای تایید</button>
+                    <button id="payment-submit-btn" type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded-lg">ارسال برای تایید</button>
                 </div>
+                <p id="payment-feedback" class="text-sm hidden"></p>
             </form>
+            <div id="student-payment-history" class="mt-6"></div>
         </div>
     </div>
 
@@ -258,6 +283,8 @@
                 courses: [],
                 payments: [],
                 paymentsLoaded: false,
+                studentPayments: [],
+                studentPaymentsLoaded: false,
                 conversations: [],
                 conversationsLoaded: false,
                 chatMessages: {},
@@ -274,15 +301,28 @@
             const chatList = document.getElementById('chat-list');
             const chatMessagesView = document.getElementById('chat-messages-view');
             const chatMessagesContainer = chatMessagesView.querySelector('.chat-messages');
+            const chatInput = document.getElementById('chat-input');
+            const chatSendBtn = document.getElementById('chat-send-btn');
             const chatTitle = document.getElementById('chat-title');
             const backToChatsBtn = document.getElementById('back-to-chats-btn');
             const chatNotificationDot = document.getElementById('chat-notification-dot');
+            const paymentForm = document.getElementById('payment-form');
+            const paymentFeedback = document.getElementById('payment-feedback');
+            const paymentSubmitBtn = document.getElementById('payment-submit-btn');
+            const studentPaymentHistoryContainer = document.getElementById('student-payment-history');
             const adminBtn = document.getElementById('adminBtn');
             const counselorBtn = document.getElementById('counselorBtn');
             const studentBtn = document.getElementById('studentBtn');
             const profileDropdown = document.getElementById('profile-dropdown');
 
             let currentRole = CURRENT_USER.isStaff ? 'admin' : (CURRENT_USER.role || 'student');
+            let activeChatUserId = null;
+            let activeChatDisplayName = '';
+            let messagePollingInterval = null;
+            let conversationPollingInterval = null;
+            const CHAT_POLL_INTERVAL = 5000;
+            let studentPaymentPollingInterval = null;
+            const STUDENT_PAYMENT_POLL_INTERVAL = 15000;
 
             function getCookie(name) {
                 let cookieValue = null;
@@ -300,17 +340,94 @@
             }
             const csrftoken = getCookie('csrftoken');
 
+            const toastContainer = document.getElementById('toast-container');
+            const showToast = (message, type = 'info') => {
+                if (!toastContainer || !message) return;
+                const icons = {
+                    success: 'fa-circle-check',
+                    error: 'fa-circle-exclamation',
+                    info: 'fa-circle-info',
+                };
+                const toast = document.createElement('div');
+                toast.className = `toast-message ${type}`;
+                toast.innerHTML = `<i class="fas ${icons[type] || icons.info} text-white text-lg"></i><span>${message}</span>`;
+                toastContainer.appendChild(toast);
+                setTimeout(() => {
+                    toast.style.opacity = '0';
+                    toast.style.transition = 'opacity 0.3s ease';
+                    setTimeout(() => toast.remove(), 300);
+                }, 4000);
+            };
+
+            const toDateInstance = (value) => {
+                if (!value) return null;
+                if (value instanceof Date) {
+                    return Number.isNaN(value.getTime()) ? null : value;
+                }
+                if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+                    const parsed = new Date(`${value}T00:00:00`);
+                    return Number.isNaN(parsed.getTime()) ? null : parsed;
+                }
+                const parsed = new Date(value);
+                return Number.isNaN(parsed.getTime()) ? null : parsed;
+            };
+
+            const formatToJalali = (value, options = { year: 'numeric', month: 'long', day: 'numeric' }) => {
+                const date = toDateInstance(value);
+                if (!date) return '';
+                return new Intl.DateTimeFormat('fa-IR-u-ca-persian', options).format(date);
+            };
+
+            const formatToJalaliDateTime = (value) => {
+                const date = toDateInstance(value);
+                if (!date) return '';
+                return new Intl.DateTimeFormat('fa-IR-u-ca-persian', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                }).format(date);
+            };
+
             async function fetchJSON(url, options = {}) {
-                const response = await fetch(url, options);
+                const mergedOptions = {
+                    credentials: 'same-origin',
+                    ...options,
+                };
+                mergedOptions.headers = {
+                    Accept: 'application/json',
+                    ...(options.headers || {}),
+                };
+
+                const response = await fetch(url, mergedOptions);
+                const isNoContent = response.status === 204;
+                const rawPayload = isNoContent ? '' : await response.text();
+
                 if (!response.ok) {
-                    const error = new Error(`Request failed with status ${response.status}`);
+                    let message = `Request failed with status ${response.status}`;
+                    if (rawPayload) {
+                        try {
+                            const errorData = JSON.parse(rawPayload);
+                            message = errorData.detail || errorData.message || message;
+                        } catch (parseError) {
+                            // ignore json parse error for non-json responses
+                        }
+                    }
+                    const error = new Error(message);
                     error.status = response.status;
                     throw error;
                 }
-                if (response.status === 204) {
+
+                if (!rawPayload) {
                     return null;
                 }
-                return await response.json();
+
+                try {
+                    return JSON.parse(rawPayload);
+                } catch (parseError) {
+                    return null;
+                }
             }
 
             const extractFileName = (path) => {
@@ -323,7 +440,7 @@
                 const sessions = (course.sessions || []).map(session => ({
                     id: session.id,
                     number: session.session_number,
-                    date: session.date,
+                    date: formatToJalali(session.date),
                     completed: session.is_completed,
                     videoUrl: session.video_url,
                 }));
@@ -361,6 +478,7 @@
                     startTime: course.start_time,
                     time: course.start_time ? course.start_time.slice(0, 5) : '',
                     startDate: course.start_date,
+                    startDateJalali: formatToJalali(course.start_date),
                     isActive: course.is_active,
                     sessions,
                     comments,
@@ -413,13 +531,132 @@
                 }
             }
 
+            function renderStudentPaymentHistory() {
+                if (!studentPaymentHistoryContainer) return;
+
+                if (!state.studentPayments.length) {
+                    studentPaymentHistoryContainer.innerHTML = `
+                        <div class="bg-gray-50 border border-dashed border-gray-300 rounded-lg p-4 text-sm text-gray-500 text-center">
+                            هنوز پرداختی ثبت نشده است.
+                        </div>
+                    `;
+                    return;
+                }
+
+                const statusLabels = {
+                    pending: 'در انتظار تایید',
+                    approved: 'تایید شده',
+                    rejected: 'رد شده',
+                };
+                const statusClassMap = {
+                    pending: 'text-amber-500',
+                    approved: 'text-green-600',
+                    rejected: 'text-red-500',
+                };
+
+                const items = state.studentPayments.map(payment => {
+                    const statusKey = payment.status || 'pending';
+                    const statusText = payment.status_display || statusLabels[statusKey] || statusKey;
+                    const statusClass = statusClassMap[statusKey] || 'text-gray-600';
+                    const amount = Number(payment.amount || 0).toLocaleString('fa-IR');
+                    const adminNotes = payment.admin_notes ? `<p class="text-xs text-gray-500 mt-2 leading-5">یادداشت ادمین: ${payment.admin_notes}</p>` : '';
+                    return `
+                        <div class="bg-indigo-50 rounded-lg p-3 mb-3 shadow-sm border border-indigo-100 last:mb-0">
+                            <div class="flex justify-between items-center text-sm">
+                                <span class="font-semibold text-gray-700">مبلغ: ${amount} تومان</span>
+                                <span class="text-xs text-gray-500">${formatToJalali(payment.payment_date)}</span>
+                            </div>
+                            <div class="flex justify-between items-center mt-2 text-sm">
+                                <span class="text-gray-500">شماره پیگیری: ${payment.reference_number}</span>
+                                <span class="font-semibold ${statusClass}">${statusText}</span>
+                            </div>
+                            ${adminNotes}
+                        </div>
+                    `;
+                }).join('');
+
+                studentPaymentHistoryContainer.innerHTML = `
+                    <h3 class="text-base font-bold text-gray-700 mb-3 flex items-center gap-2">
+                        <i class="fas fa-receipt text-indigo-500"></i>
+                        <span>سوابق پرداخت شما</span>
+                    </h3>
+                    ${items}
+                `;
+            }
+
+            async function loadStudentPayments({ notify = true } = {}) {
+                if (CURRENT_USER.role !== 'student') {
+                    state.studentPayments = [];
+                    state.studentPaymentsLoaded = true;
+                    if (studentPaymentHistoryContainer) {
+                        studentPaymentHistoryContainer.innerHTML = '';
+                    }
+                    return [];
+                }
+
+                try {
+                    const payments = await fetchJSON('/api/payments/mine/');
+                    const normalized = Array.isArray(payments) ? payments : [];
+                    const previousStatuses = new Map(state.studentPayments.map(payment => [payment.id, payment.status]));
+
+                    if (state.studentPaymentsLoaded && notify) {
+                        normalized.forEach(payment => {
+                            const previousStatus = previousStatuses.get(payment.id);
+                            if (previousStatus && previousStatus === payment.status) {
+                                return;
+                            }
+                            if (!previousStatus && payment.status === 'pending') {
+                                return;
+                            }
+                            if (payment.status === 'approved') {
+                                showToast('پرداخت شما تایید شد.', 'success');
+                            } else if (payment.status === 'rejected') {
+                                const reason = payment.admin_notes ? ` (${payment.admin_notes})` : '';
+                                showToast(`پرداخت شما رد شد.${reason}`, 'error');
+                            }
+                        });
+                    }
+
+                    state.studentPayments = normalized;
+                    state.studentPaymentsLoaded = true;
+                    renderStudentPaymentHistory();
+                    return normalized;
+                } catch (error) {
+                    if (error.status !== 403) {
+                        console.error('Error loading student payments:', error);
+                    }
+                    return state.studentPayments;
+                }
+            }
+
+            function startStudentPaymentPolling() {
+                if (CURRENT_USER.role !== 'student') {
+                    return;
+                }
+                if (studentPaymentPollingInterval) {
+                    return;
+                }
+                studentPaymentPollingInterval = setInterval(() => {
+                    loadStudentPayments({ notify: true }).catch(error => {
+                        console.error('Error while polling student payments:', error);
+                    });
+                }, STUDENT_PAYMENT_POLL_INTERVAL);
+            }
+
+            function stopStudentPaymentPolling() {
+                if (studentPaymentPollingInterval) {
+                    clearInterval(studentPaymentPollingInterval);
+                    studentPaymentPollingInterval = null;
+                }
+            }
+
             async function loadConversations(force = false) {
                 if (state.conversationsLoaded && !force) {
-                    return;
+                    return state.conversations;
                 }
                 try {
                     const conversations = await fetchJSON('/api/chat/conversations/');
-                    state.conversations = conversations;
+                    state.conversations = Array.isArray(conversations) ? conversations : [];
                 } catch (error) {
                     if (error.status !== 403) {
                         console.error('Error loading conversations:', error);
@@ -427,15 +664,214 @@
                     state.conversations = [];
                 } finally {
                     state.conversationsLoaded = true;
+                    updateNotificationIndicator();
+                }
+                return state.conversations;
+            }
+
+            async function fetchChatMessages(userId, force = false) {
+                if (!force && state.chatMessages[userId]) {
+                    return state.chatMessages[userId];
+                }
+                try {
+                    const messages = await fetchJSON(`/api/chat/messages/${userId}/`);
+                    const normalized = Array.isArray(messages) ? messages : [];
+                    state.chatMessages[userId] = normalized;
+                    return normalized;
+                } catch (error) {
+                    console.error('Error loading chat messages:', error);
+                    return state.chatMessages[userId] || [];
                 }
             }
 
-            async function fetchChatMessages(userId) {
+            function updateNotificationIndicator() {
+                if (!chatNotificationDot) {
+                    return;
+                }
+                const totalUnread = (state.conversations || []).reduce((sum, convo) => sum + (convo.unread_count || 0), 0);
+                if (totalUnread > 0) {
+                    chatNotificationDot.classList.remove('hidden');
+                } else {
+                    chatNotificationDot.classList.add('hidden');
+                }
+            }
+
+            function getConversationDisplayName(convo) {
+                if (!convo) {
+                    return 'کاربر';
+                }
+                const nameParts = [];
+                if (convo.profile) {
+                    if (convo.profile.first_name) nameParts.push(convo.profile.first_name);
+                    if (convo.profile.last_name) nameParts.push(convo.profile.last_name);
+                }
+                const displayName = nameParts.join(' ').trim();
+                return displayName || convo.username || 'کاربر';
+            }
+
+            function populateChatList() {
+                if (!chatList) {
+                    return;
+                }
+                chatList.innerHTML = '';
+                if (!state.conversations.length) {
+                    chatList.innerHTML = '<p class="text-sm text-gray-500 p-3">گفتگویی یافت نشد.</p>';
+                    updateNotificationIndicator();
+                    return;
+                }
+
+                state.conversations.forEach(convo => {
+                    const displayName = getConversationDisplayName(convo);
+                    const lastMessage = convo.last_message || '';
+                    const listItem = document.createElement('div');
+                    listItem.className = 'p-3 flex items-center gap-3 hover:bg-gray-100 cursor-pointer border-b';
+                    const avatarInitial = displayName.charAt(0) || '?';
+                    listItem.innerHTML = `<img src="https://placehold.co/40x40/e0e7ff/4338ca?text=${avatarInitial}" class="w-10 h-10 rounded-full"><div><p class="font-bold">${displayName}</p><p class="text-sm text-gray-500 truncate">${lastMessage || 'بدون پیام'}</p></div>`;
+                    listItem.addEventListener('click', () => {
+                        renderMessages(convo.id, displayName).catch(error => {
+                            console.error('Error rendering messages:', error);
+                            chatMessagesContainer.innerHTML = '<p class="text-sm text-red-500">خطا در بارگذاری پیام‌ها.</p>';
+                        });
+                    });
+                    chatList.appendChild(listItem);
+                });
+
+                updateNotificationIndicator();
+            }
+
+            function updateMessagesUI(userId) {
+                if (!chatMessagesContainer) {
+                    return;
+                }
+                const messages = state.chatMessages[userId] || [];
+                chatMessagesContainer.innerHTML = '';
+                if (!messages.length) {
+                    chatMessagesContainer.innerHTML = '<p class="text-sm text-gray-500">پیامی ثبت نشده است.</p>';
+                    return;
+                }
+
+                messages.forEach(msg => {
+                    const msgBubble = document.createElement('div');
+                    const isMe = msg.sender === CURRENT_USER.id;
+                    msgBubble.className = `max-w-xs p-3 rounded-lg ${isMe ? 'bg-indigo-500 text-white self-end' : 'bg-gray-200 text-gray-800 self-start'}`;
+                    msgBubble.textContent = msg.text || 'بدون متن';
+                    chatMessagesContainer.appendChild(msgBubble);
+                });
+                chatMessagesContainer.scrollTop = chatMessagesContainer.scrollHeight;
+            }
+
+            function haveMessagesChanged(previousMessages, nextMessages) {
+                if (previousMessages.length !== nextMessages.length) {
+                    return true;
+                }
+                if (!previousMessages.length) {
+                    return false;
+                }
+                const prevLast = previousMessages[previousMessages.length - 1];
+                const nextLast = nextMessages[nextMessages.length - 1];
+                if (!prevLast && !nextLast) {
+                    return false;
+                }
+                if (!prevLast || !nextLast) {
+                    return true;
+                }
+                return prevLast.id !== nextLast.id || prevLast.timestamp !== nextLast.timestamp || prevLast.text !== nextLast.text || prevLast.is_read !== nextLast.is_read;
+            }
+
+            function startMessagePolling(userId) {
+                stopMessagePolling();
+                if (!userId) {
+                    return;
+                }
+                messagePollingInterval = setInterval(async () => {
+                    try {
+                        const previousMessages = state.chatMessages[userId] ? [...state.chatMessages[userId]] : [];
+                        const latestMessages = await fetchChatMessages(userId, true);
+                        if (haveMessagesChanged(previousMessages, latestMessages)) {
+                            updateMessagesUI(userId);
+                        }
+                    } catch (error) {
+                        console.error('Error polling messages:', error);
+                    }
+                }, CHAT_POLL_INTERVAL);
+            }
+
+            function stopMessagePolling() {
+                if (messagePollingInterval) {
+                    clearInterval(messagePollingInterval);
+                    messagePollingInterval = null;
+                }
+            }
+
+            function startConversationPolling() {
+                if (conversationPollingInterval) {
+                    return;
+                }
+                conversationPollingInterval = setInterval(async () => {
+                    if (chatWindow.classList.contains('hidden')) {
+                        stopConversationPolling();
+                        return;
+                    }
+                    try {
+                        await loadConversations(true);
+                        if (!chatList.classList.contains('hidden')) {
+                            populateChatList();
+                        }
+                    } catch (error) {
+                        console.error('Error refreshing conversations:', error);
+                    }
+                }, CHAT_POLL_INTERVAL);
+            }
+
+            function stopConversationPolling() {
+                if (conversationPollingInterval) {
+                    clearInterval(conversationPollingInterval);
+                    conversationPollingInterval = null;
+                }
+            }
+
+            async function handleSendMessage() {
+                if (!chatInput || !chatSendBtn) {
+                    return;
+                }
+                if (!activeChatUserId) {
+                    alert('لطفا ابتدا یک گفتگو را انتخاب کنید.');
+                    return;
+                }
+                const text = chatInput.value.trim();
+                if (!text) {
+                    chatInput.focus();
+                    return;
+                }
+
+                chatSendBtn.disabled = true;
                 try {
-                    return await fetchJSON(`/api/chat/messages/${userId}/`);
+                    const response = await fetch(`/api/chat/messages/${activeChatUserId}/`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrftoken },
+                        body: JSON.stringify({ text }),
+                    });
+                    if (!response.ok) {
+                        const errorText = await response.text();
+                        throw new Error(errorText || `خطا در ارسال پیام (کد ${response.status})`);
+                    }
+                    const newMessage = await response.json();
+                    if (!Array.isArray(state.chatMessages[activeChatUserId])) {
+                        state.chatMessages[activeChatUserId] = [];
+                    }
+                    state.chatMessages[activeChatUserId].push(newMessage);
+                    updateMessagesUI(activeChatUserId);
+                    chatInput.value = '';
+                    chatInput.focus();
+                    await loadConversations(true);
+                    if (!chatList.classList.contains('hidden')) {
+                        populateChatList();
+                    }
                 } catch (error) {
-                    console.error('Error loading chat messages:', error);
-                    return [];
+                    console.error('Error sending message:', error);
+                    alert('ارسال پیام با خطا مواجه شد.');
+                } finally {
+                    chatSendBtn.disabled = false;
                 }
             }
 
@@ -483,10 +919,10 @@
 
                 const commentsHtml = course.comments.map(comment => `
                     <div class="p-3 bg-white rounded-lg shadow-sm border">
-                        <div class="flex items-center justify-between mb-2">
-                            <p class="font-semibold text-gray-700">${comment.authorName || 'کاربر'}</p>
-                            <span class="text-xs text-gray-400">${comment.createdAt ? new Date(comment.createdAt).toLocaleString('fa-IR') : ''}</span>
-                        </div>
+                            <div class="flex items-center justify-between mb-2">
+                                <p class="font-semibold text-gray-700">${comment.authorName || 'کاربر'}</p>
+                                <span class="text-xs text-gray-400">${formatToJalaliDateTime(comment.createdAt)}</span>
+                            </div>
                         <p class="text-sm text-gray-600">${comment.text || 'بدون متن'}</p>
                     </div>
                 `).join('');
@@ -647,88 +1083,66 @@
                 if (counselorFilter) {
                     counselorFilter.disabled = !showAdminControls;
                 }
+                if (role === 'student') {
+                    loadStudentPayments({ notify: false }).catch(error => {
+                        console.error('Error loading student payments:', error);
+                    });
+                    startStudentPaymentPolling();
+                } else {
+                    stopStudentPaymentPolling();
+                }
                 chatWindow.classList.add('hidden');
                 chatMessagesView.classList.add('hidden');
+                chatMessagesView.style.display = 'none';
                 chatList.classList.remove('hidden');
+                stopConversationPolling();
+                stopMessagePolling();
+                activeChatUserId = null;
+                activeChatDisplayName = '';
                 renderCalendar();
             };
 
-            const renderMessages = async (userId, otherPartyName) => {
-                chatMessagesContainer.innerHTML = '';
+            async function renderMessages(userId, otherPartyName, options = {}) {
+                const { force = false } = options;
+                activeChatUserId = userId;
+                if (typeof otherPartyName === 'string' && otherPartyName.trim()) {
+                    activeChatDisplayName = otherPartyName;
+                }
+
                 chatList.classList.add('hidden');
                 chatMessagesView.style.display = 'flex';
                 chatMessagesView.classList.remove('hidden');
                 backToChatsBtn.classList.remove('hidden');
-                chatTitle.textContent = otherPartyName;
+                chatTitle.textContent = activeChatDisplayName || 'چت';
+                chatMessagesContainer.innerHTML = '';
 
-                let messages = state.chatMessages[userId];
-                if (!messages) {
-                    messages = await fetchChatMessages(userId);
-                    state.chatMessages[userId] = messages;
-                }
+                await fetchChatMessages(userId, force);
+                updateMessagesUI(userId);
+                chatInput?.focus();
 
-                if (!messages.length) {
-                    chatMessagesContainer.innerHTML = '<p class="text-sm text-gray-500">پیامی ثبت نشده است.</p>';
-                    return;
-                }
+                await loadConversations(true);
+                startMessagePolling(userId);
+            }
 
-                messages.forEach(msg => {
-                    const msgBubble = document.createElement('div');
-                    const isMe = msg.sender === CURRENT_USER.id;
-                    msgBubble.className = `max-w-xs p-3 rounded-lg ${isMe ? 'bg-indigo-500 text-white self-end' : 'bg-gray-200 text-gray-800 self-start'}`;
-                    msgBubble.textContent = msg.text || 'بدون متن';
-                    chatMessagesContainer.appendChild(msgBubble);
-                });
-                chatMessagesContainer.scrollTop = chatMessagesContainer.scrollHeight;
-            };
-
-            const renderChatList = async () => {
+            async function renderChatList(force = false) {
                 chatMessagesContainer.innerHTML = '';
                 chatMessagesView.classList.add('hidden');
+                chatMessagesView.style.display = 'none';
                 chatList.classList.remove('hidden');
                 backToChatsBtn.classList.add('hidden');
                 chatTitle.textContent = 'چت‌ها';
+                activeChatUserId = null;
+                activeChatDisplayName = '';
+                stopMessagePolling();
 
-                if (!state.conversationsLoaded) {
+                if (force) {
+                    await loadConversations(true);
+                } else if (!state.conversationsLoaded) {
                     await loadConversations();
                 }
 
-                chatList.innerHTML = '';
-                if (!state.conversations.length) {
-                    chatList.innerHTML = '<p class="text-sm text-gray-500 p-3">گفتگویی یافت نشد.</p>';
-                    chatNotificationDot.classList.add('hidden');
-                    return;
-                }
-
-                let totalUnread = 0;
-                state.conversations.forEach(convo => {
-                    totalUnread += convo.unread_count || 0;
-                    const nameParts = [];
-                    if (convo.profile) {
-                        if (convo.profile.first_name) nameParts.push(convo.profile.first_name);
-                        if (convo.profile.last_name) nameParts.push(convo.profile.last_name);
-                    }
-                    const displayName = nameParts.join(' ') || convo.username || 'کاربر';
-                    const lastMessage = convo.last_message || '';
-                    const listItem = document.createElement('div');
-                    listItem.className = 'p-3 flex items-center gap-3 hover:bg-gray-100 cursor-pointer border-b';
-                    const avatarInitial = displayName.charAt(0) || '?';
-                    listItem.innerHTML = `<img src="https://placehold.co/40x40/e0e7ff/4338ca?text=${avatarInitial}" class="w-10 h-10 rounded-full"><div><p class="font-bold">${displayName}</p><p class="text-sm text-gray-500 truncate">${lastMessage || 'بدون پیام'}</p></div>`;
-                    listItem.addEventListener('click', () => {
-                        renderMessages(convo.id, displayName).catch(error => {
-                            console.error('Error rendering messages:', error);
-                            chatMessagesContainer.innerHTML = '<p class="text-sm text-red-500">خطا در بارگذاری پیام‌ها.</p>';
-                        });
-                    });
-                    chatList.appendChild(listItem);
-                });
-
-                if (totalUnread > 0) {
-                    chatNotificationDot.classList.remove('hidden');
-                } else {
-                    chatNotificationDot.classList.add('hidden');
-                }
-            };
+                populateChatList();
+            }
 
             async function getAdminData(force = false) {
                 if (!CURRENT_USER.isStaff) {
@@ -816,13 +1230,18 @@
                                 approved: 'تایید شده',
                                 rejected: 'رد شده',
                             };
+                            const statusClassMap = {
+                                pending: 'text-amber-500',
+                                approved: 'text-green-600',
+                                rejected: 'text-red-500',
+                            };
                             const rows = state.payments.map(payment => `
                                 <tr class="border-b">
                                     <td class="px-3 py-2 text-sm text-gray-700">${payment.student_name || '---'}</td>
                                     <td class="px-3 py-2 text-sm text-gray-700">${Number(payment.amount).toLocaleString('fa-IR')}</td>
                                     <td class="px-3 py-2 text-sm text-gray-500">${payment.reference_number}</td>
-                                    <td class="px-3 py-2 text-sm text-gray-500">${payment.payment_date}</td>
-                                    <td class="px-3 py-2 text-sm font-semibold">${statusLabels[payment.status] || payment.status}</td>
+                                    <td class="px-3 py-2 text-sm text-gray-500">${formatToJalali(payment.payment_date)}</td>
+                                    <td class="px-3 py-2 text-sm font-semibold ${statusClassMap[payment.status] || 'text-gray-600'}">${payment.status_display || statusLabels[payment.status] || payment.status}</td>
                                 </tr>
                             `).join('');
                             content = `
@@ -958,28 +1377,112 @@
 
             const openPaymentModalBtn = document.getElementById('open-payment-modal-btn');
             if (openPaymentModalBtn) {
-                openPaymentModalBtn.addEventListener('click', () => openModal('payment-modal'));
+                openPaymentModalBtn.addEventListener('click', () => {
+                    openModal('payment-modal');
+                    loadStudentPayments({ notify: false }).catch(error => {
+                        console.error('Error refreshing payment history:', error);
+                    });
+                });
+            }
+
+            if (paymentForm) {
+                paymentForm.addEventListener('submit', async (event) => {
+                    event.preventDefault();
+                    if (paymentSubmitBtn) {
+                        paymentSubmitBtn.disabled = true;
+                    }
+                    if (paymentFeedback) {
+                        paymentFeedback.textContent = '';
+                        paymentFeedback.classList.add('hidden');
+                        paymentFeedback.classList.remove('text-green-600', 'text-red-600');
+                    }
+
+                    const formData = new FormData(paymentForm);
+                    const payload = Object.fromEntries(formData.entries());
+
+                    try {
+                        const response = await fetchJSON('/api/payments/submit/', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRFToken': csrftoken,
+                            },
+                            body: JSON.stringify(payload),
+                        });
+                        const successMessage = (response && response.message) || 'پرداخت شما ثبت شد و در انتظار تایید ادمین است.';
+                        showToast(successMessage, 'success');
+                        if (paymentFeedback) {
+                            paymentFeedback.textContent = successMessage;
+                            paymentFeedback.classList.remove('hidden', 'text-red-600');
+                            paymentFeedback.classList.add('text-green-600');
+                        }
+                        paymentForm.reset();
+                        await loadStudentPayments({ notify: false });
+                    } catch (error) {
+                        const message = error.message || 'ثبت پرداخت با خطا مواجه شد.';
+                        showToast(message, 'error');
+                        if (paymentFeedback) {
+                            paymentFeedback.textContent = message;
+                            paymentFeedback.classList.remove('hidden', 'text-green-600');
+                            paymentFeedback.classList.add('text-red-600');
+                        }
+                    } finally {
+                        if (paymentSubmitBtn) {
+                            paymentSubmitBtn.disabled = false;
+                        }
+                    }
+                });
             }
 
             const chatToggleBtn = document.getElementById('chat-toggle-btn');
             if (chatToggleBtn) {
                 chatToggleBtn.addEventListener('click', () => {
                     chatWindow.classList.toggle('hidden');
-                    if (!chatWindow.classList.contains('hidden')) {
+                    const isHidden = chatWindow.classList.contains('hidden');
+                    if (!isHidden) {
                         renderChatList().catch(error => {
                             console.error('Error rendering chat list:', error);
                             chatList.innerHTML = '<p class="text-sm text-red-500 p-3">خطا در بارگذاری چت.</p>';
                         });
+                        startConversationPolling();
+                    } else {
+                        stopConversationPolling();
+                        stopMessagePolling();
+                        activeChatUserId = null;
+                        activeChatDisplayName = '';
+                        chatMessagesView.classList.add('hidden');
+                        chatMessagesView.style.display = 'none';
+                        chatList.classList.remove('hidden');
+                        chatTitle.textContent = 'چت‌ها';
                     }
                 });
             }
 
             backToChatsBtn.addEventListener('click', () => {
-                renderChatList().catch(error => {
+                renderChatList(true).catch(error => {
                     console.error('Error rendering chat list:', error);
                     chatList.innerHTML = '<p class="text-sm text-red-500 p-3">خطا در بارگذاری چت.</p>';
                 });
             });
+
+            if (chatSendBtn) {
+                chatSendBtn.addEventListener('click', () => {
+                    handleSendMessage().catch(error => {
+                        console.error('Error sending message:', error);
+                    });
+                });
+            }
+
+            if (chatInput) {
+                chatInput.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' && !event.shiftKey) {
+                        event.preventDefault();
+                        handleSendMessage().catch(error => {
+                            console.error('Error sending message:', error);
+                        });
+                    }
+                });
+            }
 
             const profileMenuBtn = document.getElementById('profile-menu-btn');
             if (profileMenuBtn && profileDropdown) {
@@ -1059,6 +1562,7 @@
             };
 
             initializeDashboard();
+            updateNotificationIndicator();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- expose a payment status endpoint and extend serializers so API responses include localized labels
- convert dashboard payment and session dates to the Jalali calendar while adding toast notifications and polling hooks
- let students submit payments with inline success feedback and review their payment history from the modal

## Testing
- python manage.py test *(fails: Django not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f36a7ef188832f890ee5b387885e57