### PR TITLE
Open web ports and verify production reachability

### DIFF
--- a/.github/placeholder
+++ b/.github/placeholder
@@ -1,0 +1,1 @@
+temporary

--- a/.github/placeholder
+++ b/.github/placeholder
@@ -1,1 +1,0 @@
-temporary

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,3 +53,66 @@ jobs:
           command_timeout: 30m
           envs: DEPLOY_SSL_EMAIL,DEPLOY_TELEGRAM_BOT_TOKEN,DEPLOY_TELEGRAM_WORKER_URL,DEPLOY_KAVENEGAR_API_KEY,DEPLOY_KAVENEGAR_SENDER
           script_path: deploy/deploy.sh
+
+      - name: Open web ports and verify local services
+        uses: appleboy/ssh-action@v1.2.5
+        env:
+          DEPLOY_SSH_PORT: ${{ secrets.SERVER_PORT }}
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          port: ${{ secrets.SERVER_PORT }}
+          timeout: 60s
+          command_timeout: 10m
+          envs: DEPLOY_SSH_PORT
+          script: |
+            set -eu
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update
+            apt-get install -y ufw curl
+            ufw allow "${DEPLOY_SSH_PORT:-22}/tcp"
+            ufw allow 80/tcp
+            ufw allow 443/tcp
+            ufw --force enable
+            systemctl restart nginx
+            systemctl restart kimiagarkhune
+            systemctl is-active --quiet nginx
+            systemctl is-active --quiet kimiagarkhune
+            ss -lntp | grep -E ':(80|443)[[:space:]]' || true
+            curl --fail --silent --show-error --max-time 20 \
+              -H 'Host: panel.kimiagarkhoone.com' \
+              http://127.0.0.1/ >/dev/null
+
+      - name: Verify public IP endpoint
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error --head \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            --connect-timeout 10 --max-time 30 \
+            -H 'Host: panel.kimiagarkhoone.com' \
+            "http://${SERVER_HOST}/"
+
+      - name: Verify DNS and public domain
+        shell: bash
+        env:
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          DOMAIN: panel.kimiagarkhoone.com
+        run: |
+          set -euo pipefail
+          RESOLVED_IP="$(getent ahostsv4 "$DOMAIN" | awk 'NR == 1 {print $1}')"
+          test -n "$RESOLVED_IP" || {
+            echo "::error::DNS A record for $DOMAIN is not publicly resolvable."
+            exit 1
+          }
+          test "$RESOLVED_IP" = "$SERVER_HOST" || {
+            echo "::error::$DOMAIN resolves to $RESOLVED_IP instead of $SERVER_HOST."
+            exit 1
+          }
+          curl --fail --silent --show-error --head \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            --connect-timeout 10 --max-time 30 \
+            "https://${DOMAIN}/"


### PR DESCRIPTION
## What changed

- Opens SSH, HTTP, and HTTPS ports with UFW after deployment.
- Restarts and verifies Nginx and the Django service on the server.
- Tests the public server IP from the GitHub runner.
- Verifies that `panel.kimiagarkhoone.com` resolves to the configured server and responds over HTTPS.

This prevents a deployment from appearing successful when SSH worked but the website is not publicly reachable.