### PR TITLE
Add temporary diagnostics for plan defaults deployment

### DIFF
--- a/.github/workflows/diagnose-plan-defaults.yml
+++ b/.github/workflows/diagnose-plan-defaults.yml
@@ -1,0 +1,47 @@
+name: Diagnose plan defaults deployment
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    name: Diagnose Django migration on server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run concise server diagnostics
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          port: ${{ secrets.SERVER_PORT }}
+          timeout: 60s
+          command_timeout: 5m
+          script: |
+            set -u
+            sleep 25
+            set -a
+            . /etc/kimiagarkhune.env
+            set +a
+            cd /var/www/KimiagarKhune
+
+            echo "SERVER_COMMIT=$(git rev-parse HEAD)"
+
+            set +e
+            CHECK_OUTPUT="$(./venv/bin/python manage.py check 2>&1)"
+            CHECK_STATUS=$?
+            printf '%s\n' "$CHECK_OUTPUT" | tail -n 50
+            if [ "$CHECK_STATUS" -ne 0 ]; then
+              exit "$CHECK_STATUS"
+            fi
+
+            MIGRATE_OUTPUT="$(./venv/bin/python manage.py migrate --noinput 2>&1)"
+            MIGRATE_STATUS=$?
+            printf '%s\n' "$MIGRATE_OUTPUT" | tail -n 80
+            exit "$MIGRATE_STATUS"


### PR DESCRIPTION
این workflow موقت، بعد از push روی سرور `manage.py check` و `migrate` را با خروجی کوتاه اجرا می‌کند تا خطای دیپلوی داده‌های پیش‌فرض Plan مشخص شود. بعد از رفع خطا حذف خواهد شد.