### PR TITLE
Rebuild Plan calendar behavior with regression coverage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Validate Plan source files
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --check plans/static/plans/plan-runtime.js
+          python3 -m py_compile \
+            deploy/plan_e2e.py \
+            plans/plan_page.py \
+            plans/weekly_plans.py
+
       - name: Validate required secrets
         shell: bash
         env:
@@ -29,12 +39,14 @@ jobs:
           SERVER_USER: ${{ secrets.SERVER_USER }}
           SERVER_PASSWORD: ${{ secrets.SERVER_PASSWORD }}
           SERVER_PORT: ${{ secrets.SERVER_PORT }}
+          DJANGO_ADMIN_PASSWORD: ${{ secrets.DJANGO_ADMIN_PASSWORD }}
         run: |
           set -euo pipefail
           test -n "$SERVER_HOST" || { echo "Missing SERVER_HOST secret"; exit 1; }
           test -n "$SERVER_USER" || { echo "Missing SERVER_USER secret"; exit 1; }
           test -n "$SERVER_PASSWORD" || { echo "Missing SERVER_PASSWORD secret"; exit 1; }
           test -n "$SERVER_PORT" || { echo "Missing SERVER_PORT secret"; exit 1; }
+          test -n "$DJANGO_ADMIN_PASSWORD" || { echo "Missing DJANGO_ADMIN_PASSWORD secret"; exit 1; }
 
       - name: Bootstrap and deploy server
         uses: appleboy/ssh-action@v1.2.5
@@ -238,3 +250,20 @@ jobs:
             --retry 10 --retry-delay 10 --retry-all-errors \
             --connect-timeout 10 --max-time 30 \
             "https://${DOMAIN}/"
+
+      - name: Run Plan browser regression
+        shell: bash
+        env:
+          PLAN_BASE_URL: https://panel.kimiagarkhoone.com
+          PLAN_USERNAME: ${{ secrets.DJANGO_ADMIN_USERNAME }}
+          PLAN_PASSWORD: ${{ secrets.DJANGO_ADMIN_PASSWORD }}
+          PLAN_STUDENT_LABEL: نمونه تجربی دوازدهم
+          PLAN_TEST_WEEK: 1499-01-01
+        run: |
+          set -euo pipefail
+          export PLAN_USERNAME="${PLAN_USERNAME:-admin}"
+          python3 -m venv .plan-browser-venv
+          .plan-browser-venv/bin/pip install -q --upgrade pip
+          .plan-browser-venv/bin/pip install -q playwright
+          .plan-browser-venv/bin/python -m playwright install --with-deps chromium
+          .plan-browser-venv/bin/python deploy/plan_e2e.py

--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -3,8 +3,11 @@ name: Validate Plan behavior
 on:
   pull_request:
     paths:
+      - 'accounts/migrations/0004_loginotp.py'
       - 'plans/**'
+      - 'deploy/plan_e2e.py'
       - 'config/test_settings.py'
+      - '.github/workflows/deploy.yml'
       - '.github/workflows/validate-plan.yml'
   workflow_dispatch:
 
@@ -20,8 +23,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Validate JavaScript syntax
-        run: node --check plans/static/plans/plan-runtime.js
+      - name: Validate Plan source syntax
+        run: |
+          node --check plans/static/plans/plan-runtime.js
+          python3 -m py_compile \
+            deploy/plan_e2e.py \
+            plans/plan_page.py \
+            plans/weekly_plans.py
 
       - name: Install Python dependencies
         shell: bash

--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -27,11 +27,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y default-libmysqlclient-dev pkg-config
+          sudo apt-get update -qq >/dev/null
+          sudo apt-get install -y -qq default-libmysqlclient-dev pkg-config >/dev/null
           python3 -m venv .venv
-          .venv/bin/pip install --upgrade pip setuptools wheel
-          .venv/bin/pip install -r requirements.txt
+          .venv/bin/pip install -q --upgrade pip setuptools wheel
+          .venv/bin/pip install -q -r requirements.txt
 
       - name: Run Plan regression tests
         env:
@@ -40,4 +40,4 @@ jobs:
           .venv/bin/python manage.py test \
             plans.test_plan_runtime \
             plans.test_plan_defaults \
-            --verbosity 2
+            --verbosity 1

--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -36,8 +36,21 @@ jobs:
       - name: Run Plan regression tests
         env:
           DJANGO_SETTINGS_MODULE: config.test_settings
+        shell: bash
         run: |
+          set +e
           .venv/bin/python manage.py test \
             plans.test_plan_runtime \
             plans.test_plan_defaults \
-            --verbosity 1
+            --verbosity 1 > plan-test-output.txt 2>&1
+          status=$?
+          cat plan-test-output.txt
+          exit "$status"
+
+      - name: Upload Plan test output
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: plan-test-output
+          path: plan-test-output.txt
+          retention-days: 3

--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -1,0 +1,43 @@
+name: Validate Plan behavior
+
+on:
+  pull_request:
+    paths:
+      - 'plans/**'
+      - 'config/test_settings.py'
+      - '.github/workflows/validate-plan.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-plan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate JavaScript syntax
+        run: node --check plans/static/plans/plan-runtime.js
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y default-libmysqlclient-dev pkg-config
+          python3 -m venv .venv
+          .venv/bin/pip install --upgrade pip setuptools wheel
+          .venv/bin/pip install -r requirements.txt
+
+      - name: Run Plan regression tests
+        env:
+          DJANGO_SETTINGS_MODULE: config.test_settings
+        run: |
+          .venv/bin/python manage.py test \
+            plans.test_plan_runtime \
+            plans.test_plan_defaults \
+            --verbosity 2

--- a/accounts/migrations/0004_loginotp.py
+++ b/accounts/migrations/0004_loginotp.py
@@ -2,19 +2,20 @@ from django.db import migrations, models
 
 
 def ensure_index(schema_editor, table_name, index_name, columns):
-    """Create the given index only when it is missing."""
+    """Create the given index only when it is missing on the active backend."""
 
-    schema_editor.connection.ensure_connection()
-    with schema_editor.connection.cursor() as cursor:
-        cursor.execute(f"SHOW INDEX FROM `{table_name}`")
-        existing_indexes = {row[2] for row in cursor.fetchall()}
+    connection = schema_editor.connection
+    connection.ensure_connection()
+    with connection.cursor() as cursor:
+        constraints = connection.introspection.get_constraints(cursor, table_name)
 
-    if index_name in existing_indexes:
+    if index_name in constraints:
         return
 
-    column_sql = ", ".join(f"`{column}`" for column in columns)
+    quote = schema_editor.quote_name
+    column_sql = ", ".join(quote(column) for column in columns)
     schema_editor.execute(
-        f"CREATE INDEX `{index_name}` ON `{table_name}` ({column_sql})"
+        f"CREATE INDEX {quote(index_name)} ON {quote(table_name)} ({column_sql})"
     )
 
 

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -1,0 +1,16 @@
+from .settings import *  # noqa: F403,F401
+
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]
+
+STATICFILES_DIRS = []
+EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"

--- a/deploy/plan_e2e.py
+++ b/deploy/plan_e2e.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import os
+import sys
+from urllib.parse import urljoin
+
+from playwright.sync_api import Page, sync_playwright
+
+
+BASE_URL = os.environ.get("PLAN_BASE_URL", "https://panel.kimiagarkhoone.com").rstrip("/") + "/"
+USERNAME = os.environ.get("PLAN_USERNAME", "").strip()
+PASSWORD = os.environ.get("PLAN_PASSWORD", "")
+TEST_WEEK = os.environ.get("PLAN_TEST_WEEK", "1499-01-01")
+STUDENT_LABEL = os.environ.get("PLAN_STUDENT_LABEL", "نمونه تجربی دوازدهم")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+    print(f"PASS: {message}")
+
+
+def drop_palette(page: Page, source_selector: str, day_index: int, top_pixels: int) -> None:
+    result = page.evaluate(
+        """
+        ({sourceSelector, dayIndex, topPixels}) => {
+          const $source = window.jQuery(sourceSelector).first();
+          const $target = window.jQuery('.calendar .day-column').eq(dayIndex).find('.task-container');
+          if (!$source.length || !$target.length || !$target.hasClass('ui-droppable')) {
+            return {ok: false, source: $source.length, target: $target.length};
+          }
+          const callback = $target.droppable('option', 'drop');
+          const offset = $target.offset();
+          callback.call(
+            $target[0],
+            window.jQuery.Event('drop', {pageY: offset.top + topPixels}),
+            {
+              draggable: $source,
+              offset: {top: offset.top + topPixels, left: offset.left + 10}
+            }
+          );
+          return {ok: true};
+        }
+        """,
+        {
+            "sourceSelector": source_selector,
+            "dayIndex": day_index,
+            "topPixels": top_pixels,
+        },
+    )
+    require(bool(result.get("ok")), f"drop source {source_selector} into day {day_index}")
+
+
+def clear_calendar(page: Page) -> None:
+    page.evaluate(
+        """
+        () => {
+          window.jQuery('.calendar-task').each(function () {
+            const $task = window.jQuery(this);
+            if ($task.hasClass('ui-draggable')) $task.draggable('destroy');
+            if ($task.hasClass('ui-resizable')) $task.resizable('destroy');
+            $task.find('select.select2-hidden-accessible').each(function () {
+              try { window.jQuery(this).select2('destroy'); } catch (_) {}
+            });
+            $task.remove();
+          });
+        }
+        """
+    )
+
+
+def load_test_week(page: Page) -> None:
+    page.select_option("#student-select", label=STUDENT_LABEL)
+    page.evaluate(
+        """
+        value => {
+          const $input = window.jQuery('#weekSelector');
+          $input.val(value).trigger('input').trigger('change');
+        }
+        """,
+        TEST_WEEK,
+    )
+    page.click("#loadWeek")
+    page.wait_for_function(
+        "window.planRuntimeState && window.planRuntimeState.loaded && !window.planRuntimeState.loading",
+        timeout=30_000,
+    )
+    page.wait_for_function(
+        "window.jQuery('.calendar .task-container.ui-droppable').length === 7",
+        timeout=10_000,
+    )
+
+
+def main() -> int:
+    if not USERNAME or not PASSWORD:
+        print("PLAN_USERNAME and PLAN_PASSWORD are required.", file=sys.stderr)
+        return 2
+
+    page_errors: list[str] = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(locale="fa-IR", viewport={"width": 1600, "height": 1000})
+        page = context.new_page()
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        page.on("dialog", lambda dialog: dialog.accept())
+
+        page.goto(urljoin(BASE_URL, "login/"), wait_until="domcontentloaded", timeout=30_000)
+        page.fill("#username", USERNAME)
+        page.fill("#password", PASSWORD)
+        page.click('form button[type="submit"]')
+        page.wait_for_url("**/plan/", timeout=30_000)
+        page.wait_for_function("window.jQuery && window.jQuery.ui", timeout=20_000)
+        page.wait_for_function("window.planRuntimeState", timeout=20_000)
+
+        require(page.locator('script[data-plan-runtime="true"]').count() == 1, "runtime is loaded exactly once")
+        require(page.locator(".calendar .day-column").count() == 7, "seven calendar day columns exist")
+
+        load_test_week(page)
+        require(page.locator(".calendar .task-container.ui-droppable").count() == 7, "all days accept drops")
+        clear_calendar(page)
+
+        drop_palette(page, '.events-box .plan-event-palette[data-kind="event"]', 0, 70)
+        event = page.locator('.calendar .day-column').nth(0).locator('.calendar-task[data-box-type="ایونت"]').first
+        require(event.count() == 1, "event box is created")
+        require("ui-draggable" in (event.get_attribute("class") or ""), "event is draggable")
+        require("ui-resizable" in (event.get_attribute("class") or ""), "event is resizable")
+        require(event.locator(".time-label").inner_text().strip() == "08:00 - 09:30", "drop time is calculated from position")
+
+        event.locator(".task-title").fill("جلسه E2E")
+        page.evaluate(
+            """
+            () => {
+              const $task = window.jQuery('.calendar .day-column').eq(0).find('.calendar-task[data-box-type="ایونت"]').first();
+              const stop = $task.resizable('option', 'stop');
+              $task.css('height', '70px');
+              stop.call($task[0], window.jQuery.Event('resizestop'), {size: {height: 70}});
+            }
+            """
+        )
+        require(event.locator(".time-label").inner_text().strip() == "08:00 - 10:00", "resize updates the end time")
+
+        event.locator(".tick-btn").click()
+        require(page.locator(".assignments-box .plan-assignment-palette").count() == 1, "event creates an assignment palette item")
+        drop_palette(page, ".assignments-box .plan-assignment-palette", 1, 140)
+        require(
+            page.locator('.calendar .day-column').nth(1).locator('.calendar-task[data-box-type="تکلیف"]').count() == 1,
+            "assignment is dropped into another day",
+        )
+
+        drop_palette(page, '.events-box .plan-event-palette[data-kind="floating"]', 2, 70)
+        require(
+            page.locator('.calendar .day-column').nth(2).locator('.calendar-task[data-box-type="شناور"].floating').count() == 1,
+            "floating box keeps its own type and style",
+        )
+
+        page.check("#examWeekCheckbox")
+        require(page.locator(".events-box .exam-task").count() == 4, "exam week exposes four exam templates")
+        drop_palette(page, ".events-box .exam-task", 3, 70)
+        exam = page.locator('.calendar .day-column').nth(3).locator('.calendar-task[data-box-type="ایونت"]').first
+        require(exam.count() == 1, "exam template creates an event")
+        require(exam.evaluate("element => parseFloat(element.style.height) >= 120"), "exam duration controls box height")
+
+        lesson_count = page.locator(".subjects-box .plan-lesson-palette").count()
+        require(lesson_count > 0, "student lessons are loaded")
+        drop_palette(page, ".subjects-box .plan-lesson-palette", 4, 70)
+        study = page.locator('.calendar .day-column').nth(4).locator('.calendar-task[data-box-type="مطالعه"].extended-task').first
+        require(study.count() == 1, "lesson creates an extended study box")
+        require(study.get_attribute("data-lesson-id") is not None, "study box keeps lesson id")
+        require(study.locator(".task-chapter").count() == 1, "study box has chapter selector")
+        require(study.locator(".task-extra").count() == 1, "study box has test-count selector")
+
+        before_repeat = page.locator('.calendar-task[data-box-type="مطالعه"]').count()
+        study.locator(".repeat-btn").click()
+        after_repeat = page.locator('.calendar-task[data-box-type="مطالعه"]').count()
+        require(after_repeat > before_repeat, "repeat copies study boxes to free days")
+
+        second_day = page.locator(".calendar .day-column").nth(1)
+        before_rest = second_day.locator(".calendar-task").count()
+        second_day.locator(".disable-day-checkbox").check()
+        require(second_day.locator(".calendar-task").count() == 0, "rest day temporarily removes its boxes")
+        second_day.locator(".disable-day-checkbox").uncheck()
+        require(second_day.locator(".calendar-task").count() == before_rest, "rest day restores its boxes")
+
+        first_day = page.locator(".calendar .day-column").nth(0)
+        before_holiday = first_day.locator('.calendar-task[data-box-type="ایونت"]').count()
+        first_day.locator(".remove-events-checkbox").check()
+        require(first_day.locator('.calendar-task[data-box-type="ایونت"]').count() == 0, "holiday hides event boxes")
+        first_day.locator(".remove-events-checkbox").uncheck()
+        require(first_day.locator('.calendar-task[data-box-type="ایونت"]').count() == before_holiday, "holiday restores event boxes")
+
+        removable = page.locator('.calendar-task[data-box-type="مطالعه"]').last
+        total_before_remove = page.locator(".calendar-task").count()
+        removable.locator(".remove-btn").click()
+        require(page.locator(".calendar-task").count() == total_before_remove - 1, "remove button deletes one box")
+
+        with page.expect_response(lambda response: response.url.endswith("/save-weekly-report/") and response.request.method == "POST", timeout=30_000) as save_info:
+            page.click(".save-btn")
+        save_response = save_info.value
+        require(save_response.ok, "save API returns success")
+        save_payload = save_response.json()
+        require(save_payload.get("status") == "success", "save response reports success")
+
+        page.reload(wait_until="domcontentloaded")
+        page.wait_for_function("window.planRuntimeState", timeout=20_000)
+        load_test_week(page)
+        saved_types = set(
+            page.locator(".calendar-task").evaluate_all(
+                "elements => elements.map(element => element.dataset.boxType)"
+            )
+        )
+        require({"ایونت", "تکلیف", "شناور", "مطالعه"}.issubset(saved_types), "all box types survive save and reload")
+        require(page.locator(".calendar-task.ui-draggable.ui-resizable").count() == page.locator(".calendar-task").count(), "reloaded boxes remain draggable and resizable")
+
+        require(not page_errors, "browser produced no uncaught JavaScript errors: " + " | ".join(page_errors))
+        context.close()
+        browser.close()
+
+    print("Plan browser regression completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+
+from plans import lesson_catalog
+
+
+RUNTIME_PATH = "plans/plan-runtime.js"
+
+
+def _append_runtime_script(response):
+    """Append the isolated Plan runtime immediately before the real closing body.
+
+    The legacy template contains literal ``</body>`` strings inside JavaScript
+    template literals used for PDF windows.  Therefore this intentionally uses
+    the final closing body marker and never a first-match replacement.
+    """
+
+    content_type = response.get("Content-Type", "")
+    if response.status_code != 200 or "text/html" not in content_type:
+        return response
+
+    static_url = f"{settings.STATIC_URL.rstrip('/')}/{RUNTIME_PATH}"
+    script = f'<script src="{static_url}" data-plan-runtime="true"></script>'.encode(
+        "utf-8"
+    )
+    if script in response.content:
+        return response
+
+    marker = b"</body>"
+    marker_index = response.content.rfind(marker)
+    if marker_index < 0:
+        raise RuntimeError("The rendered Plan page has no closing body tag.")
+
+    response.content = (
+        response.content[:marker_index]
+        + script
+        + b"\n"
+        + response.content[marker_index:]
+    )
+    response.headers.pop("Content-Length", None)
+    return response
+
+
+@login_required
+def plan_view(request):
+    response = lesson_catalog.plan_view(request)
+    return _append_runtime_script(response)

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -9,11 +9,18 @@ from plans import lesson_catalog
 RUNTIME_PATH = "plans/plan-runtime.js"
 
 
+def _runtime_url() -> str:
+    static_url = str(settings.STATIC_URL or "/static/")
+    if not static_url.startswith(("/", "http://", "https://")):
+        static_url = "/" + static_url
+    return f"{static_url.rstrip('/')}/{RUNTIME_PATH}"
+
+
 def _append_runtime_script(response):
     """Append the isolated Plan runtime immediately before the real closing body.
 
     The legacy template contains literal ``</body>`` strings inside JavaScript
-    template literals used for PDF windows.  Therefore this intentionally uses
+    template literals used for PDF windows. Therefore this intentionally uses
     the final closing body marker and never a first-match replacement.
     """
 
@@ -21,8 +28,7 @@ def _append_runtime_script(response):
     if response.status_code != 200 or "text/html" not in content_type:
         return response
 
-    static_url = f"{settings.STATIC_URL.rstrip('/')}/{RUNTIME_PATH}"
-    script = f'<script src="{static_url}" data-plan-runtime="true"></script>'.encode(
+    script = f'<script src="{_runtime_url()}" data-plan-runtime="true"></script>'.encode(
         "utf-8"
     )
     if script in response.content:

--- a/plans/static/plans/plan-runtime.js
+++ b/plans/static/plans/plan-runtime.js
@@ -1,0 +1,1054 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$ || !$.ui || !window.moment) {
+    console.error('Plan runtime requires jQuery, jQuery UI and Moment.js.');
+    return;
+  }
+
+  const BASE_HOUR = 6;
+  const MINUTES_PER_DAY_VIEW = 18 * 60;
+  const PIXELS_PER_HOUR = 35;
+  const PIXELS_PER_MINUTE = PIXELS_PER_HOUR / 60;
+  const GRID_MINUTES = 15;
+  const GRID_PIXELS = GRID_MINUTES * PIXELS_PER_MINUTE;
+  const DEFAULT_DURATION = 90;
+  const CANONICAL_DAYS = [
+    'شنبه',
+    'یک‌شنبه',
+    'دوشنبه',
+    'سه‌شنبه',
+    'چهارشنبه',
+    'پنج‌شنبه',
+    'جمعه'
+  ];
+  const JS_DAY_TO_PERSIAN = {
+    6: 'شنبه',
+    0: 'یک‌شنبه',
+    1: 'دوشنبه',
+    2: 'سه‌شنبه',
+    3: 'چهارشنبه',
+    4: 'پنج‌شنبه',
+    5: 'جمعه'
+  };
+  const EXAM_FALLBACK = [
+    { name: 'آزمون آزمایشی', duration_minutes: 210 },
+    { name: 'تحلیل آزمون', duration_minutes: 240 },
+    { name: 'پیش آزمون و تحلیل آن', duration_minutes: 360 },
+    { name: 'مرور و آمادگی آزمون', duration_minutes: 240 }
+  ];
+
+  const state = {
+    loaded: false,
+    loading: false,
+    saving: false,
+    reportId: null,
+    studentId: null,
+    start: null,
+    end: null,
+    examTemplates: EXAM_FALLBACK.slice(),
+    eventTemplates: [],
+    currentMajorCode: window.currentMajorCode || ''
+  };
+
+  window.planRuntimeState = state;
+
+  function dayKey(value) {
+    return String(value || '')
+      .trim()
+      .replace(/[\u200c\u200e\u200f\s]/g, '')
+      .replace(/[يى]/g, 'ی')
+      .replace(/ك/g, 'ک');
+  }
+
+  function normalizeDay(value) {
+    const key = dayKey(value);
+    return CANONICAL_DAYS.find(function (day) {
+      return dayKey(day) === key;
+    }) || null;
+  }
+
+  function englishDigits(value) {
+    const source = String(value || '');
+    const persian = '۰۱۲۳۴۵۶۷۸۹';
+    const arabic = '٠١٢٣٤٥٦٧٨٩';
+    return source.replace(/[۰-۹٠-٩]/g, function (digit) {
+      const persianIndex = persian.indexOf(digit);
+      if (persianIndex >= 0) {
+        return String(persianIndex);
+      }
+      return String(arabic.indexOf(digit));
+    });
+  }
+
+  function pad(value) {
+    return String(value).padStart(2, '0');
+  }
+
+  function formatClock(totalMinutes) {
+    let normalized = Math.round(totalMinutes) % (24 * 60);
+    if (normalized < 0) {
+      normalized += 24 * 60;
+    }
+    return pad(Math.floor(normalized / 60)) + ':' + pad(normalized % 60);
+  }
+
+  function parseClock(value) {
+    if (!value) {
+      return null;
+    }
+    const raw = String(value);
+    if (raw.indexOf('T') >= 0) {
+      const parsed = moment.parseZone(raw);
+      if (!parsed.isValid()) {
+        return null;
+      }
+      return parsed.hour() * 60 + parsed.minute();
+    }
+    const parts = raw.split(':');
+    if (parts.length < 2) {
+      return null;
+    }
+    const hours = Number(parts[0]);
+    const minutes = Number(parts[1]);
+    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+      return null;
+    }
+    return hours * 60 + minutes;
+  }
+
+  function viewMinute(clockMinutes) {
+    let result = clockMinutes - BASE_HOUR * 60;
+    if (result < 0) {
+      result += 24 * 60;
+    }
+    return result;
+  }
+
+  function timeToTop(value) {
+    const clock = parseClock(value);
+    if (clock === null) {
+      return 0;
+    }
+    return Math.max(0, Math.min(viewMinute(clock), MINUTES_PER_DAY_VIEW)) * PIXELS_PER_MINUTE;
+  }
+
+  function durationBetween(startValue, endValue, explicitDuration) {
+    const explicit = Number(explicitDuration);
+    if (Number.isFinite(explicit) && explicit > 0) {
+      return explicit;
+    }
+    const start = parseClock(startValue);
+    const end = parseClock(endValue);
+    if (start === null || end === null) {
+      return DEFAULT_DURATION;
+    }
+    let duration = end - start;
+    if (duration <= 0) {
+      duration += 24 * 60;
+    }
+    return Math.max(GRID_MINUTES, Math.min(duration, MINUTES_PER_DAY_VIEW));
+  }
+
+  function snapPixels(value) {
+    return Math.round(Number(value || 0) / GRID_PIXELS) * GRID_PIXELS;
+  }
+
+  function clampTop(value, height, containerHeight) {
+    const maximum = Math.max(0, containerHeight - height);
+    return Math.max(0, Math.min(snapPixels(value), maximum));
+  }
+
+  function taskTitle($task) {
+    const $title = $task.find('.task-title').first();
+    if ($title.is('input, textarea')) {
+      return String($title.val() || '').trim();
+    }
+    return String($title.text() || '').trim();
+  }
+
+  function updateTimeLabel($task) {
+    const top = Number.parseFloat($task.css('top')) || 0;
+    const height = Number.parseFloat($task.css('height')) || GRID_PIXELS;
+    const start = BASE_HOUR * 60 + Math.round(top / PIXELS_PER_MINUTE);
+    const end = start + Math.round(height / PIXELS_PER_MINUTE);
+    $task.find('.time-label').first().text(formatClock(start) + ' - ' + formatClock(end));
+  }
+
+  function hasOverlap($task, top, height, $container) {
+    const candidateTop = Number.isFinite(top) ? top : (Number.parseFloat($task.css('top')) || 0);
+    const candidateHeight = Number.isFinite(height) ? height : $task.outerHeight();
+    const candidateBottom = candidateTop + candidateHeight;
+    let overlap = false;
+
+    ($container || $task.parent()).find('.calendar-task').not($task).each(function () {
+      const $other = $(this);
+      if (!$other.is(':visible')) {
+        return;
+      }
+      const otherTop = Number.parseFloat($other.css('top')) || 0;
+      const otherBottom = otherTop + $other.outerHeight();
+      if (!(candidateBottom <= otherTop || candidateTop >= otherBottom)) {
+        overlap = true;
+        return false;
+      }
+    });
+    return overlap;
+  }
+
+  function destroyTaskWidgets($task) {
+    $task.find('select.select2-hidden-accessible').each(function () {
+      try {
+        $(this).select2('destroy');
+      } catch (error) {
+        console.warn('Could not destroy Select2 instance.', error);
+      }
+    });
+    if ($task.hasClass('ui-draggable')) {
+      $task.draggable('destroy');
+    }
+    if ($task.hasClass('ui-resizable')) {
+      $task.resizable('destroy');
+    }
+  }
+
+  function initCalendarTask($task) {
+    if (!$task || !$task.length) {
+      return;
+    }
+
+    if ($task.hasClass('ui-draggable')) {
+      $task.draggable('destroy');
+    }
+    if ($task.hasClass('ui-resizable')) {
+      $task.resizable('destroy');
+    }
+
+    $task.draggable({
+      grid: [GRID_PIXELS, GRID_PIXELS],
+      scroll: false,
+      cancel: 'button, input, select, textarea, .select2-container',
+      start: function () {
+        const $current = $(this);
+        $current.data('runtimeOriginalParent', $current.parent());
+        $current.data('runtimeOriginalTop', Number.parseFloat($current.css('top')) || 0);
+        $current.data('runtimeDropped', false);
+      },
+      drag: function (event, ui) {
+        const $current = $(this);
+        const containerHeight = $current.parent().innerHeight();
+        ui.position.top = clampTop(ui.position.top, $current.outerHeight(), containerHeight);
+        $current.css('top', ui.position.top);
+        updateTimeLabel($current);
+      },
+      stop: function (event, ui) {
+        const $current = $(this);
+        if ($current.data('runtimeDropped')) {
+          $current.removeData('runtimeDropped');
+          return;
+        }
+        const $container = $current.parent();
+        const top = clampTop(ui.position.top, $current.outerHeight(), $container.innerHeight());
+        if (hasOverlap($current, top, $current.outerHeight(), $container)) {
+          $current.css('top', $current.data('runtimeOriginalTop'));
+        } else {
+          $current.css('top', top);
+        }
+        updateTimeLabel($current);
+      }
+    }).resizable({
+      handles: 's',
+      grid: [GRID_PIXELS, GRID_PIXELS],
+      minHeight: GRID_PIXELS,
+      start: function () {
+        const $current = $(this);
+        $current.data('runtimeOriginalHeight', $current.outerHeight());
+        const top = Number.parseFloat($current.css('top')) || 0;
+        $current.resizable('option', 'maxHeight', Math.max(GRID_PIXELS, $current.parent().innerHeight() - top));
+      },
+      resize: function (event, ui) {
+        ui.size.height = Math.max(GRID_PIXELS, snapPixels(ui.size.height));
+        $(this).css('height', ui.size.height);
+        updateTimeLabel($(this));
+      },
+      stop: function (event, ui) {
+        const $current = $(this);
+        const height = Math.max(GRID_PIXELS, snapPixels(ui.size.height));
+        if (hasOverlap($current, Number.parseFloat($current.css('top')) || 0, height, $current.parent())) {
+          $current.css('height', $current.data('runtimeOriginalHeight'));
+        } else {
+          $current.css('height', height);
+        }
+        updateTimeLabel($current);
+      }
+    });
+
+    updateTimeLabel($task);
+  }
+
+  window.calculateTop = timeToTop;
+  window.calculateHeight = function (startValue, endValue) {
+    return durationBetween(startValue, endValue) * PIXELS_PER_MINUTE;
+  };
+  window.updateTimeLabel = updateTimeLabel;
+  window.checkOverlap = function ($task) {
+    return hasOverlap($task);
+  };
+  window.initCalendarTask = initCalendarTask;
+
+  function createButton(className, label, title) {
+    return $('<button type="button"></button>')
+      .addClass(className)
+      .attr('title', title || label)
+      .text(label);
+  }
+
+  function addExamPattern($task, title) {
+    if (!/آزمون|تحلیل آزمون/.test(title || '')) {
+      return;
+    }
+    const patterns = ['exam-pattern-1', 'exam-pattern-2', 'exam-pattern-3'];
+    const index = Math.abs(String(title).split('').reduce(function (total, character) {
+      return total + character.charCodeAt(0);
+    }, 0)) % patterns.length;
+    $task.addClass(patterns[index]);
+  }
+
+  function addTestOptions($select, selected) {
+    $select.append($('<option></option>').attr('value', '').text('-'));
+    for (let value = 5; value <= 100; value += 5) {
+      $select.append($('<option></option>').attr('value', value).text(value));
+    }
+    if (selected) {
+      $select.val(String(selected));
+    }
+  }
+
+  function initStudyControls($task, task) {
+    const $chapter = $task.find('.task-chapter');
+    const $extra = $task.find('.task-extra');
+    const lessonId = $task.attr('data-lesson-id');
+    const grade = $task.attr('data-grade');
+
+    if (task.chapter_id && task.chapter_text) {
+      $chapter.append(new Option(task.chapter_text, task.chapter_id, true, true));
+    }
+    addTestOptions($extra, task.optional_tests_count || task.extra || 0);
+
+    if ($.fn.select2) {
+      $chapter.select2({
+        placeholder: 'شماره فصل',
+        dropdownParent: $task,
+        width: '100%',
+        theme: 'bootstrap-5',
+        allowClear: true,
+        ajax: {
+          url: '/get-chapters/',
+          dataType: 'json',
+          delay: 200,
+          data: function (params) {
+            return {
+              lesson_id: lessonId,
+              grade: grade,
+              major_code: state.currentMajorCode,
+              q: params.term || ''
+            };
+          },
+          processResults: function (data) {
+            return { results: Array.isArray(data) ? data : [] };
+          }
+        }
+      });
+      $extra.select2({
+        placeholder: 'تعداد تست',
+        dropdownParent: $task,
+        width: '100%',
+        theme: 'bootstrap-5',
+        minimumResultsForSearch: Infinity
+      });
+    }
+  }
+
+  function buildCalendarTask(task) {
+    const type = String(task.box_type || 'مطالعه');
+    const title = String(task.title || task.lesson_name || type).trim();
+    const duration = Math.max(GRID_MINUTES, Number(task.duration_minutes) || DEFAULT_DURATION);
+    const $task = $('<div class="calendar-task"></div>')
+      .attr('data-box-type', type)
+      .attr('data-duration-minutes', duration)
+      .css({
+        top: Number(task.top || 0) + 'px',
+        height: duration * PIXELS_PER_MINUTE + 'px',
+        left: '5%'
+      });
+
+    if (task.lesson_id) {
+      $task.attr('data-lesson-id', task.lesson_id);
+    }
+    if (task.lesson_name) {
+      $task.attr('data-lesson-name', task.lesson_name);
+    }
+    if (task.grade) {
+      $task.attr('data-grade', task.grade);
+    }
+    if (task.lesson_type) {
+      $task.attr('data-lesson-type', task.lesson_type);
+    }
+
+    $task.append(createButton('remove-btn', '✖', 'حذف'));
+
+    if (type === 'مطالعه') {
+      $task.addClass('extended-task');
+      $task.append(createButton('repeat-btn', 'تکرار', 'تکرار در روزهای دیگر'));
+      $task.append($('<div class="task-title"></div>').text(title));
+      const $info = $('<div class="task-info"></div>').css({
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        maxWidth: '80%'
+      });
+      $info.append($('<select class="task-chapter p-1 text-sm leading-tight"></select>'));
+      $info.append($('<select class="task-extra p-1 text-sm leading-tight"></select>'));
+      $info.append($('<div class="hidden extra-info"></div>').text('تعداد تست: ' + (task.optional_tests_count || 0)));
+      $info.append($('<div class="time-label"></div>'));
+      $task.append($info);
+      initStudyControls($task, task);
+    } else {
+      if (type === 'ایونت') {
+        $task.addClass('event-task');
+        $task.append(createButton('tick-btn', 'افزودن تکلیف', 'ایجاد تکلیف از ایونت'));
+      } else if (type === 'شناور') {
+        $task.addClass('floating');
+      } else if (type === 'تکلیف') {
+        $task.addClass('assignment-task');
+      }
+      $task.append(
+        $('<input type="text" class="task-title task-inp editable">').val(title)
+      );
+      $task.append($('<div class="time-label"></div>'));
+      addExamPattern($task, title);
+    }
+
+    if (task.lesson_name && window.subjectColors && window.subjectColors[task.lesson_name]) {
+      $task.css('background-color', window.subjectColors[task.lesson_name]);
+    }
+
+    initCalendarTask($task);
+    return $task;
+  }
+
+  function taskDataFromElement($task) {
+    const top = Number.parseFloat($task.css('top')) || 0;
+    const height = $task.outerHeight();
+    const startMinutes = BASE_HOUR * 60 + Math.round(top / PIXELS_PER_MINUTE);
+    const duration = Math.max(GRID_MINUTES, Math.round(height / PIXELS_PER_MINUTE));
+    return {
+      title: taskTitle($task),
+      start: formatClock(startMinutes) + ':00',
+      end: formatClock(startMinutes + duration) + ':00',
+      box_type: $task.attr('data-box-type') || 'مطالعه',
+      lesson_id: $task.attr('data-lesson-id') || null,
+      lesson_type: $task.attr('data-lesson-type') || '',
+      grade: $task.attr('data-grade') || null,
+      chapter_id: $task.find('.task-chapter').val() || null,
+      chapter_text: $task.find('.task-chapter option:selected').text() || '',
+      optional_tests_count: Number($task.find('.task-extra').val()) || 0,
+      duration_minutes: duration,
+      top: top
+    };
+  }
+
+  function initializePaletteDraggable($items) {
+    $items.each(function () {
+      const $item = $(this);
+      if ($item.hasClass('ui-draggable')) {
+        $item.draggable('destroy');
+      }
+      $item.draggable({
+        helper: function () {
+          return $(this).clone().css({ width: '120px' }).appendTo('body');
+        },
+        appendTo: 'body',
+        cursorAt: { top: 0, left: 60 },
+        revert: 'invalid',
+        zIndex: 10000,
+        start: function (event, ui) {
+          ui.helper.css('width', '120px');
+        }
+      });
+    });
+  }
+
+  function renderLessons(response) {
+    state.currentMajorCode = response.major_code || '';
+    window.currentMajorCode = state.currentMajorCode;
+
+    const groups = [
+      ['#specialized-task-list', response.specialized_lessons || [], 'تخصصی'],
+      ['#general-task-list', response.general_lessons || [], 'عمومی']
+    ];
+    groups.forEach(function (group) {
+      const $list = $(group[0]).empty();
+      group[1].forEach(function (lesson) {
+        $list.append(
+          $('<div class="task plan-lesson-palette"></div>')
+            .attr('data-lesson-id', lesson.id)
+            .attr('data-lesson-name', lesson.name)
+            .attr('data-grade', lesson.grade_id)
+            .attr('data-lesson-type', group[2])
+            .text(lesson.name + ' ' + lesson.grade)
+        );
+      });
+    });
+    initializePaletteDraggable($('.subjects-box .plan-lesson-palette'));
+    $('.grade-filter').trigger('change');
+  }
+
+  function renderEventPalette(response) {
+    if (response && Array.isArray(response.event_boxes) && response.event_boxes.length) {
+      state.eventTemplates = response.event_boxes;
+      const $list = $('.events-box .task-list').empty();
+      response.event_boxes.forEach(function (box) {
+        const $item = $('<div class="task plan-event-palette"></div>')
+          .text(box.name)
+          .attr('data-box-type', box.box_type)
+          .attr('data-kind', box.kind)
+          .attr('data-duration-minutes', box.duration_minutes || DEFAULT_DURATION);
+        if (box.kind === 'floating') {
+          $item.addClass('floating-box');
+        }
+        $list.append($item);
+      });
+    }
+    if (response && Array.isArray(response.exam_boxes) && response.exam_boxes.length) {
+      state.examTemplates = response.exam_boxes;
+    }
+    initializePaletteDraggable($('.events-box .task'));
+  }
+
+  function bindExamPalette() {
+    $('#examWeekCheckbox').off('change').on('change.planRuntime', function () {
+      const $list = $(this).closest('.events-box').find('.task-list');
+      $list.find('.exam-task').remove();
+      if (!this.checked) {
+        return;
+      }
+      state.examTemplates.forEach(function (box) {
+        $list.append(
+          $('<div class="task exam-task"></div>')
+            .text(box.name || box.title)
+            .attr('data-duration-minutes', box.duration_minutes || Number(box.duration) * 60 || DEFAULT_DURATION)
+        );
+      });
+      initializePaletteDraggable($list.find('.exam-task'));
+    });
+  }
+
+  function restoreOriginalPosition($task) {
+    const $originalParent = $task.data('runtimeOriginalParent');
+    if ($originalParent && $originalParent.length) {
+      $task.appendTo($originalParent);
+    }
+    $task.css({ top: $task.data('runtimeOriginalTop') || 0, left: '5%' });
+    updateTimeLabel($task);
+  }
+
+  function initializeDroppables() {
+    $('.task-container').each(function () {
+      const $container = $(this);
+      if ($container.hasClass('ui-droppable')) {
+        $container.droppable('destroy');
+      }
+      $container.droppable({
+        accept: '.task, .calendar-task, .other-plan-task',
+        tolerance: 'pointer',
+        drop: function (event, ui) {
+          if (window.readOnlyMode || !state.loaded) {
+            return;
+          }
+          const $target = $(this);
+          const $day = $target.closest('.day-column');
+          if ($day.hasClass('disabled-day')) {
+            if (ui.draggable.hasClass('calendar-task')) {
+              restoreOriginalPosition(ui.draggable);
+            }
+            return;
+          }
+
+          const $source = ui.draggable;
+          const targetOffset = $target.offset();
+          const helperTop = ui.offset ? ui.offset.top : event.pageY;
+          const desiredTop = clampTop(
+            helperTop - targetOffset.top,
+            $source.hasClass('calendar-task') ? $source.outerHeight() : DEFAULT_DURATION * PIXELS_PER_MINUTE,
+            $target.innerHeight()
+          );
+
+          if ($source.hasClass('calendar-task')) {
+            const height = $source.outerHeight();
+            if (hasOverlap($source, desiredTop, height, $target)) {
+              restoreOriginalPosition($source);
+              $source.data('runtimeDropped', true);
+              return;
+            }
+            $source.appendTo($target).css({ top: desiredTop, left: '5%' });
+            $source.data('runtimeDropped', true);
+            updateTimeLabel($source);
+            return;
+          }
+
+          let task;
+          let consumeSource = false;
+          const sourceTitle = String($source.text() || '').trim();
+
+          if ($source.hasClass('exam-task')) {
+            task = {
+              title: sourceTitle,
+              box_type: 'ایونت',
+              duration_minutes: Number($source.attr('data-duration-minutes')) || DEFAULT_DURATION,
+              top: desiredTop
+            };
+            consumeSource = true;
+          } else if ($source.hasClass('floating-box') || $source.attr('data-kind') === 'floating') {
+            task = {
+              title: sourceTitle || 'باکس شناور',
+              box_type: 'شناور',
+              duration_minutes: Number($source.attr('data-duration-minutes')) || DEFAULT_DURATION,
+              top: desiredTop
+            };
+          } else if ($source.closest('.assignments-box').length) {
+            task = {
+              title: sourceTitle,
+              box_type: 'تکلیف',
+              duration_minutes: DEFAULT_DURATION,
+              top: desiredTop
+            };
+            consumeSource = true;
+          } else if ($source.closest('.events-box').length) {
+            task = {
+              title: sourceTitle === 'ایونت' ? '' : sourceTitle,
+              box_type: 'ایونت',
+              duration_minutes: Number($source.attr('data-duration-minutes')) || DEFAULT_DURATION,
+              top: desiredTop
+            };
+          } else {
+            task = {
+              title: sourceTitle,
+              box_type: 'مطالعه',
+              lesson_id: $source.attr('data-lesson-id'),
+              lesson_name: $source.attr('data-lesson-name'),
+              lesson_type: $source.attr('data-lesson-type') || ($source.closest('#specialized-task-list').length ? 'تخصصی' : 'عمومی'),
+              grade: $source.attr('data-grade'),
+              duration_minutes: DEFAULT_DURATION,
+              top: desiredTop
+            };
+          }
+
+          const $newTask = buildCalendarTask(task);
+          const newHeight = $newTask.outerHeight();
+          const correctedTop = clampTop(desiredTop, newHeight, $target.innerHeight());
+          $newTask.css('top', correctedTop);
+          if (hasOverlap($newTask, correctedTop, newHeight, $target)) {
+            destroyTaskWidgets($newTask);
+            $newTask.remove();
+            return;
+          }
+          $target.append($newTask);
+          initCalendarTask($newTask);
+          if (consumeSource) {
+            $source.remove();
+          }
+        }
+      });
+    });
+  }
+
+  function resetCalendar() {
+    $('.day-column').each(function () {
+      const $day = $(this);
+      $day.removeClass('disabled-day');
+      $day.find('.disable-day-checkbox, .remove-events-checkbox').prop('checked', false);
+      $day.removeData('runtimeCachedTasks runtimeCachedEvents cachedTasks cachedEvents');
+      $day.find('.task-container').empty();
+    });
+    $('#important-events').val('');
+  }
+
+  function reorderCalendar(start) {
+    const columns = {};
+    $('.calendar .day-column').each(function () {
+      const canonical = normalizeDay($(this).attr('data-day'));
+      if (canonical) {
+        columns[canonical] = $(this);
+      }
+    });
+
+    const $calendar = $('.calendar').empty();
+    for (let index = 0; index < 7; index += 1) {
+      const date = start.clone().add(index, 'days');
+      const dayName = JS_DAY_TO_PERSIAN[date.day()];
+      const $column = columns[dayName];
+      if (!$column) {
+        continue;
+      }
+      $column.attr('data-day', dayName).attr('data-date', date.format('YYYY-MM-DD'));
+      $column.find('h4').first().text(dayName + ' - ' + date.format('jD jMMMM'));
+      $calendar.append($column);
+    }
+  }
+
+  function renderTask(task) {
+    const dayName = normalizeDay(task.day_of_week);
+    if (!dayName) {
+      return;
+    }
+    const $container = $('.day-column').filter(function () {
+      return normalizeDay($(this).attr('data-day')) === dayName;
+    }).find('.task-container');
+    if (!$container.length) {
+      return;
+    }
+
+    const top = timeToTop(task.start_time || task.start);
+    const duration = durationBetween(task.start_time || task.start, task.end_time || task.end, task.duration_minutes);
+    const $task = buildCalendarTask(Object.assign({}, task, { top: top, duration_minutes: duration }));
+    const correctedTop = clampTop(top, $task.outerHeight(), $container.innerHeight());
+    $task.css('top', correctedTop);
+    $container.append($task);
+    initCalendarTask($task);
+  }
+
+  function applyDisabledDays(days) {
+    (days || []).forEach(function (day) {
+      const canonical = normalizeDay(day);
+      if (!canonical) {
+        return;
+      }
+      const $column = $('.day-column').filter(function () {
+        return normalizeDay($(this).attr('data-day')) === canonical;
+      });
+      $column.find('.disable-day-checkbox').prop('checked', true).trigger('change');
+    });
+  }
+
+  function ajaxJson(options) {
+    return new Promise(function (resolve, reject) {
+      $.ajax(options).done(resolve).fail(function (xhr, status, error) {
+        const response = xhr.responseJSON || {};
+        reject(new Error(response.message || response.detail || error || status || 'خطای ارتباط با سرور'));
+      });
+    });
+  }
+
+  async function loadLessons(studentId) {
+    const response = await ajaxJson({
+      url: '/get-lessons-for-student/',
+      method: 'GET',
+      dataType: 'json',
+      data: { student_id: studentId }
+    });
+    renderLessons(response);
+  }
+
+  async function loadWeek() {
+    if (state.loading) {
+      return;
+    }
+    const rawDate = englishDigits($('#weekSelector').val());
+    const studentId = $('#student-select').val();
+    if (!rawDate || !studentId) {
+      window.alert('لطفاً تاریخ و دانش‌آموز را انتخاب کنید.');
+      return;
+    }
+
+    const selected = moment(rawDate, 'jYYYY-jMM-jDD', true);
+    if (!selected.isValid()) {
+      window.alert('تاریخ انتخاب‌شده معتبر نیست.');
+      return;
+    }
+
+    state.loading = true;
+    $('#loadWeek').prop('disabled', true).text('در حال بارگذاری...');
+    try {
+      const check = await ajaxJson({
+        url: '/check-weekly-report/',
+        method: 'GET',
+        dataType: 'json',
+        data: {
+          selected_date: selected.format('YYYY-MM-DD'),
+          student_id: studentId
+        }
+      });
+
+      if (check.exists === 'future') {
+        window.alert('یک برنامه آینده از تاریخ ' + check.week_start + ' وجود دارد.');
+        return;
+      }
+
+      const start = check.exists === 'current'
+        ? moment(check.week_start, 'YYYY-MM-DD')
+        : selected.clone().startOf('day');
+      const end = check.exists === 'current'
+        ? moment(check.week_end, 'YYYY-MM-DD')
+        : start.clone().add(6, 'days');
+
+      state.studentId = String(studentId);
+      state.start = start.clone();
+      state.end = end.clone();
+      state.reportId = check.report_id || null;
+      state.loaded = true;
+      window.readOnlyMode = false;
+
+      resetCalendar();
+      reorderCalendar(start);
+      initializeDroppables();
+      await loadLessons(studentId);
+
+      const report = await ajaxJson({
+        url: '/get-weekly-report-details/',
+        method: 'GET',
+        dataType: 'json',
+        data: {
+          week_start: start.format('YYYY-MM-DD'),
+          student_id: studentId
+        }
+      });
+
+      state.reportId = report.report_id || null;
+      $('#important-events').val(report.important_events || '');
+      (report.tasks || []).forEach(renderTask);
+      applyDisabledDays(report.disabled_days || []);
+
+      if (!report.tasks || !report.tasks.length) {
+        const defaults = await ajaxJson({
+          url: '/get_default_events/',
+          method: 'GET',
+          dataType: 'json',
+          data: { student_id: studentId }
+        });
+        (defaults || []).forEach(function (event) {
+          renderTask(Object.assign({}, event, {
+            title: event.name,
+            box_type: 'ایونت',
+            duration_minutes: durationBetween(event.start_time, event.end_time)
+          }));
+        });
+      }
+
+      initializeDroppables();
+      $('#pageOverlay').remove();
+      $('.save-btn').prop('disabled', false).text('ذخیره');
+    } catch (error) {
+      console.error(error);
+      state.loaded = false;
+      window.alert(error.message || 'بارگذاری برنامه انجام نشد.');
+    } finally {
+      state.loading = false;
+      $('#loadWeek').prop('disabled', false).text('بارگذاری هفته');
+    }
+  }
+
+  function collectPlanPayload() {
+    if (!state.loaded || !state.start || !state.end || !state.studentId) {
+      throw new Error('ابتدا هفته و دانش‌آموز را بارگذاری کنید.');
+    }
+    const days = [];
+    $('.calendar .day-column').each(function () {
+      const $column = $(this);
+      const dayName = normalizeDay($column.attr('data-day'));
+      if (!dayName) {
+        return;
+      }
+      const tasks = [];
+      $column.find('.task-container > .calendar-task').each(function () {
+        tasks.push(taskDataFromElement($(this)));
+      });
+      days.push({
+        day: dayName,
+        disabled: $column.hasClass('disabled-day') || $column.find('.disable-day-checkbox').is(':checked'),
+        tasks: tasks
+      });
+    });
+    return {
+      student_id: state.studentId,
+      week_start: state.start.format('YYYY-MM-DD'),
+      week_end: state.end.format('YYYY-MM-DD'),
+      important_events: $('#important-events').val() || '',
+      days: days
+    };
+  }
+
+  function csrfToken() {
+    const cookie = document.cookie.split(';').map(function (part) {
+      return part.trim();
+    }).find(function (part) {
+      return part.indexOf('csrftoken=') === 0;
+    });
+    if (cookie) {
+      return decodeURIComponent(cookie.substring('csrftoken='.length));
+    }
+    return $('input[name="csrfmiddlewaretoken"]').first().val() || '';
+  }
+
+  async function saveWeek() {
+    if (state.saving) {
+      return;
+    }
+    let payload;
+    try {
+      payload = collectPlanPayload();
+    } catch (error) {
+      window.alert(error.message);
+      return;
+    }
+
+    state.saving = true;
+    $('.save-btn').prop('disabled', true).text('در حال ذخیره...');
+    try {
+      const response = await ajaxJson({
+        url: '/save-weekly-report/',
+        method: 'POST',
+        dataType: 'json',
+        contentType: 'application/json; charset=utf-8',
+        headers: { 'X-CSRFToken': csrfToken() },
+        data: JSON.stringify(payload)
+      });
+      state.reportId = response.report_id || state.reportId;
+      window.alert('برنامه با موفقیت ذخیره شد.');
+    } catch (error) {
+      console.error(error);
+      window.alert(error.message || 'ذخیره برنامه انجام نشد.');
+    } finally {
+      state.saving = false;
+      $('.save-btn').prop('disabled', false).text('ذخیره');
+    }
+  }
+
+  function bindCalendarActions() {
+    $(document)
+      .off('click', '.remove-btn')
+      .on('click.planRuntime', '.remove-btn', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const $task = $(this).closest('.calendar-task');
+        destroyTaskWidgets($task);
+        $task.remove();
+      })
+      .off('click', '.tick-btn')
+      .on('click.planRuntime', '.tick-btn', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const title = taskTitle($(this).closest('.calendar-task'));
+        if (!title) {
+          window.alert('ابتدا عنوان ایونت را وارد کنید.');
+          return;
+        }
+        const $assignment = $('<div class="task plan-assignment-palette"></div>')
+          .text('آمادگی و تکلیف ' + title);
+        $('.assignments-box .task-list').append($assignment);
+        initializePaletteDraggable($assignment);
+      })
+      .off('click', '.repeat-btn')
+      .on('click.planRuntime', '.repeat-btn', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const $source = $(this).closest('.calendar-task');
+        const data = taskDataFromElement($source);
+        const top = Number.parseFloat($source.css('top')) || 0;
+        const height = $source.outerHeight();
+        $('.day-column').each(function () {
+          const $column = $(this);
+          const $target = $column.find('.task-container');
+          if ($target[0] === $source.parent()[0] || $column.hasClass('disabled-day')) {
+            return;
+          }
+          if (hasOverlap($(), top, height, $target)) {
+            return;
+          }
+          const $clone = buildCalendarTask(Object.assign({}, data, { top: top }));
+          $clone.find('.repeat-btn').remove();
+          $target.append($clone);
+          initCalendarTask($clone);
+        });
+      })
+      .off('change', '.disable-day-checkbox')
+      .on('change.planRuntime', '.disable-day-checkbox', function () {
+        const $column = $(this).closest('.day-column');
+        const $container = $column.find('.task-container');
+        if (this.checked) {
+          $column.data('runtimeCachedTasks', $container.children().detach());
+          $column.addClass('disabled-day');
+        } else {
+          $column.removeClass('disabled-day');
+          const tasks = $column.data('runtimeCachedTasks');
+          if (tasks && tasks.length) {
+            $container.append(tasks);
+            tasks.each(function () {
+              initCalendarTask($(this));
+            });
+          }
+          $column.removeData('runtimeCachedTasks');
+        }
+      })
+      .off('change', '.remove-events-checkbox')
+      .on('change.planRuntime', '.remove-events-checkbox', function () {
+        const $column = $(this).closest('.day-column');
+        const $container = $column.find('.task-container');
+        if (this.checked) {
+          $column.data(
+            'runtimeCachedEvents',
+            $container.find('.calendar-task[data-box-type="ایونت"]').detach()
+          );
+        } else {
+          const events = $column.data('runtimeCachedEvents');
+          if (events && events.length) {
+            $container.append(events);
+            events.each(function () {
+              initCalendarTask($(this));
+            });
+          }
+          $column.removeData('runtimeCachedEvents');
+        }
+      })
+      .off('change.planRuntime', '.task-extra')
+      .on('change.planRuntime', '.task-extra', function () {
+        $(this).siblings('.extra-info').text('تعداد تست: ' + ($(this).val() || 0));
+      });
+  }
+
+  function removeLegacyCoreHandlers() {
+    $('#loadWeek').off('click').on('click.planRuntime', function (event) {
+      event.preventDefault();
+      loadWeek();
+    });
+    $('.save-btn').off('click').on('click.planRuntime', function (event) {
+      event.preventDefault();
+      saveWeek();
+    });
+    $('#examWeekCheckbox').off('change');
+    bindExamPalette();
+    bindCalendarActions();
+  }
+
+  async function initialize() {
+    removeLegacyCoreHandlers();
+    initializePaletteDraggable($('.subjects-box .task, .events-box .task, .assignments-box .task'));
+    initializeDroppables();
+
+    try {
+      const palette = await ajaxJson({
+        url: '/get_default_boxes/',
+        method: 'GET',
+        dataType: 'json'
+      });
+      renderEventPalette(palette);
+      bindExamPalette();
+    } catch (error) {
+      console.warn('Default palette API unavailable; using template palette.', error);
+    }
+
+    window.dispatchEvent(new CustomEvent('plan:runtime-ready'));
+  }
+
+  $(initialize);
+})(window, document, window.jQuery);

--- a/plans/test_plan_runtime.py
+++ b/plans/test_plan_runtime.py
@@ -1,0 +1,243 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from accounts.models import Student
+from plans.default_plan_data import ensure_advisor_for_user, seed_plan_defaults
+from plans.models import Box, WeeklyReport, WeeklyReportDetail
+from plans.weekly_plans import normalize_day_name
+
+
+class PlanRuntimeRegressionTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="plan-runtime-admin",
+            email="plan-runtime@example.com",
+            password="test-password",
+        )
+        self.advisor = ensure_advisor_for_user(self.admin)
+        seed_plan_defaults(advisor=self.advisor)
+        self.student = Student.objects.get(
+            profile__user__username="demo_plan_student_t"
+        )
+        self.target_student = Student.objects.get(
+            profile__user__username="demo_plan_student_r"
+        )
+        self.client.force_login(self.admin)
+
+    def test_runtime_is_appended_after_legacy_scripts(self):
+        response = self.client.get("/plan/")
+        self.assertEqual(response.status_code, 200)
+        content = response.content
+
+        runtime_marker = b'/static/plans/plan-runtime.js'
+        self.assertEqual(content.count(runtime_marker), 1)
+        runtime_index = content.index(runtime_marker)
+        final_body_index = content.rfind(b"</body>")
+        previous_script_index = content.rfind(b"</script>", 0, runtime_index)
+
+        self.assertGreater(previous_script_index, 0)
+        self.assertGreater(runtime_index, previous_script_index)
+        self.assertGreater(final_body_index, runtime_index)
+        self.assertNotIn(b"plan-defaults.js", content)
+        self.assertIn(b"function initCalendarTask", content)
+        self.assertIn(b"function updateTimeLabel", content)
+
+    def test_day_names_are_normalized_without_silent_saturday_fallback(self):
+        self.assertEqual(normalize_day_name("یکشنبه"), "یک‌شنبه")
+        self.assertEqual(normalize_day_name("سه شنبه"), "سه‌شنبه")
+        self.assertEqual(normalize_day_name("پنج\u200cشنبه"), "پنج‌شنبه")
+        self.assertIsNone(normalize_day_name("روز نامعتبر"))
+
+    def test_save_and_reload_preserves_types_times_duration_and_selected_week(self):
+        payload = {
+            "student_id": self.student.pk,
+            "week_start": "2038-01-02",
+            "week_end": "2038-01-08",
+            "important_events": "آزمون ذخیره و بازیابی",
+            "days": [
+                {
+                    "day": "شنبه",
+                    "disabled": False,
+                    "tasks": [
+                        {
+                            "title": "جلسه مشاوره",
+                            "start": "08:15:00",
+                            "end": "09:45:00",
+                            "box_type": "ایونت",
+                            "duration_minutes": 90,
+                        },
+                        {
+                            "title": "یادداشت آزاد",
+                            "start": "10:00:00",
+                            "end": "10:30:00",
+                            "box_type": "شناور",
+                            "duration_minutes": 30,
+                        },
+                    ],
+                },
+                {
+                    "day": "یکشنبه",
+                    "disabled": False,
+                    "tasks": [
+                        {
+                            "title": "تکلیف مدرسه",
+                            "start": "23:00:00",
+                            "end": "00:00:00",
+                            "box_type": "تکلیف",
+                            "duration_minutes": 60,
+                        }
+                    ],
+                },
+                {
+                    "day": "سه شنبه",
+                    "disabled": True,
+                    "tasks": [],
+                },
+            ],
+        }
+
+        response = self.client.post(
+            "/save-weekly-report/",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        body = response.json()
+        self.assertEqual(body["status"], "success")
+        self.assertEqual(body["week_start"], "2038-01-02")
+        self.assertEqual(body["tasks_count"], 3)
+
+        report = WeeklyReport.objects.get(pk=body["report_id"])
+        self.assertEqual(report.week_start.date().isoformat(), "2038-01-02")
+        self.assertEqual(report.week_end.date().isoformat(), "2038-01-08")
+        self.assertEqual(report.disabled_days, "سه‌شنبه")
+        self.assertEqual(report.important_events, "آزمون ذخیره و بازیابی")
+
+        event_box = Box.objects.get(name="جلسه مشاوره")
+        self.assertFalse(event_box.is_default)
+        self.assertEqual(event_box.duration_minutes, 90)
+        self.assertEqual(event_box.box_type.name, "ایونت")
+
+        overnight = WeeklyReportDetail.objects.get(box__name="تکلیف مدرسه")
+        self.assertEqual(overnight.day_of_week, "یک‌شنبه")
+        self.assertEqual(
+            int((overnight.end_time - overnight.start_time).total_seconds() // 60),
+            60,
+        )
+        self.assertEqual(overnight.box.box_type.name, "تکلیف")
+
+        details_response = self.client.get(
+            "/get-weekly-report-details/",
+            {
+                "student_id": self.student.pk,
+                "week_start": "2038-01-02T00:00:00+00:00",
+            },
+        )
+        self.assertEqual(details_response.status_code, 200, details_response.content)
+        details = details_response.json()
+        self.assertEqual(details["report_id"], report.pk)
+        self.assertEqual(details["disabled_days"], ["سه‌شنبه"])
+        self.assertEqual({task["box_type"] for task in details["tasks"]}, {"ایونت", "شناور", "تکلیف"})
+        self.assertEqual({task["day_of_week"] for task in details["tasks"]}, {"شنبه", "یک‌شنبه"})
+
+        updated_payload = {
+            **payload,
+            "important_events": "نسخه دوم",
+            "days": [
+                {
+                    "day": "شنبه",
+                    "disabled": False,
+                    "tasks": [
+                        {
+                            "title": "نسخه دوم ایونت",
+                            "start": "12:00:00",
+                            "end": "13:00:00",
+                            "box_type": "ایونت",
+                            "duration_minutes": 60,
+                        }
+                    ],
+                }
+            ],
+        }
+        second_response = self.client.post(
+            "/save-weekly-report/",
+            data=json.dumps(updated_payload),
+            content_type="application/json",
+        )
+        self.assertEqual(second_response.status_code, 200, second_response.content)
+        self.assertEqual(WeeklyReport.objects.filter(student=self.student).count(), 1)
+        self.assertFalse(Box.objects.filter(name="جلسه مشاوره").exists())
+        self.assertTrue(Box.objects.filter(name="نسخه دوم ایونت", is_default=False).exists())
+
+    def test_invalid_day_is_rejected_instead_of_saved_as_saturday(self):
+        response = self.client.post(
+            "/save-weekly-report/",
+            data=json.dumps(
+                {
+                    "student_id": self.student.pk,
+                    "week_start": "2038-02-01",
+                    "week_end": "2038-02-07",
+                    "days": [
+                        {"day": "روز نامعتبر", "disabled": False, "tasks": []}
+                    ],
+                }
+            ),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(
+            WeeklyReport.objects.filter(
+                student=self.student,
+                week_start__date="2038-02-01",
+            ).exists()
+        )
+
+    def test_copy_day_accepts_day_alias_and_adjusts_target_date(self):
+        source_payload = {
+            "student_id": self.student.pk,
+            "week_start": "2038-03-06",
+            "week_end": "2038-03-12",
+            "days": [
+                {
+                    "day": "شنبه",
+                    "disabled": False,
+                    "tasks": [
+                        {
+                            "title": "باکس قابل کپی",
+                            "start": "09:00:00",
+                            "end": "10:30:00",
+                            "box_type": "ایونت",
+                            "duration_minutes": 90,
+                        }
+                    ],
+                }
+            ],
+        }
+        source_response = self.client.post(
+            "/save-weekly-report/",
+            data=json.dumps(source_payload),
+            content_type="application/json",
+        )
+        self.assertEqual(source_response.status_code, 200, source_response.content)
+
+        copy_response = self.client.post(
+            "/copy_day_plan/",
+            {
+                "source_student_id": self.student.pk,
+                "target_student_id": self.target_student.pk,
+                "source_date": "2038-03-06",
+                "target_day_of_week": "یکشنبه",
+            },
+        )
+        self.assertEqual(copy_response.status_code, 200, copy_response.content)
+        copied = WeeklyReportDetail.objects.get(
+            report__student=self.target_student,
+            box__name="باکس قابل کپی",
+        )
+        self.assertEqual(copied.day_of_week, "یک‌شنبه")
+        self.assertEqual(copied.start_time.date().isoformat(), "2038-03-07")
+        self.assertEqual(copied.start_time.strftime("%H:%M"), "09:00")
+        self.assertEqual(copied.end_time.strftime("%H:%M"), "10:30")

--- a/plans/test_plan_runtime.py
+++ b/plans/test_plan_runtime.py
@@ -7,6 +7,7 @@ from accounts.models import Student
 from plans.default_plan_data import ensure_advisor_for_user, seed_plan_defaults
 from plans.models import Box, WeeklyReport, WeeklyReportDetail
 from plans.weekly_plans import normalize_day_name
+from plans.weekly_plans_v2 import date_for_day
 
 
 class PlanRuntimeRegressionTests(TestCase):
@@ -50,6 +51,75 @@ class PlanRuntimeRegressionTests(TestCase):
         self.assertEqual(normalize_day_name("سه شنبه"), "سه‌شنبه")
         self.assertEqual(normalize_day_name("پنج\u200cشنبه"), "پنج‌شنبه")
         self.assertIsNone(normalize_day_name("روز نامعتبر"))
+
+    def test_selected_start_day_is_calendar_offset_zero(self):
+        self.assertEqual(
+            date_for_day(
+                __import__("datetime").date(2038, 1, 6),
+                "چهارشنبه",
+            ).isoformat(),
+            "2038-01-06",
+        )
+
+        payload = {
+            "student_id": self.student.pk,
+            "week_start": "2038-01-06",
+            "week_end": "2038-01-12",
+            "days": [
+                {
+                    "day": "چهارشنبه",
+                    "disabled": False,
+                    "tasks": [
+                        {
+                            "title": "روز اول واقعی",
+                            "start": "08:00:00",
+                            "end": "09:00:00",
+                            "box_type": "ایونت",
+                        }
+                    ],
+                },
+                {
+                    "day": "پنجشنبه",
+                    "disabled": False,
+                    "tasks": [
+                        {
+                            "title": "روز دوم واقعی",
+                            "start": "10:00:00",
+                            "end": "11:00:00",
+                            "box_type": "ایونت",
+                        }
+                    ],
+                },
+                {
+                    "day": "سه شنبه",
+                    "disabled": False,
+                    "tasks": [
+                        {
+                            "title": "روز هفتم واقعی",
+                            "start": "12:00:00",
+                            "end": "13:00:00",
+                            "box_type": "ایونت",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.post(
+            "/save-weekly-report/",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+        dates = {
+            detail.box.name: detail.start_time.date().isoformat()
+            for detail in WeeklyReportDetail.objects.filter(
+                report__student=self.student
+            ).select_related("box")
+        }
+        self.assertEqual(dates["روز اول واقعی"], "2038-01-06")
+        self.assertEqual(dates["روز دوم واقعی"], "2038-01-07")
+        self.assertEqual(dates["روز هفتم واقعی"], "2038-01-12")
 
     def test_save_and_reload_preserves_types_times_duration_and_selected_week(self):
         payload = {
@@ -140,8 +210,14 @@ class PlanRuntimeRegressionTests(TestCase):
         details = details_response.json()
         self.assertEqual(details["report_id"], report.pk)
         self.assertEqual(details["disabled_days"], ["سه‌شنبه"])
-        self.assertEqual({task["box_type"] for task in details["tasks"]}, {"ایونت", "شناور", "تکلیف"})
-        self.assertEqual({task["day_of_week"] for task in details["tasks"]}, {"شنبه", "یک‌شنبه"})
+        self.assertEqual(
+            {task["box_type"] for task in details["tasks"]},
+            {"ایونت", "شناور", "تکلیف"},
+        )
+        self.assertEqual(
+            {task["day_of_week"] for task in details["tasks"]},
+            {"شنبه", "یک‌شنبه"},
+        )
 
         updated_payload = {
             **payload,
@@ -168,9 +244,13 @@ class PlanRuntimeRegressionTests(TestCase):
             content_type="application/json",
         )
         self.assertEqual(second_response.status_code, 200, second_response.content)
-        self.assertEqual(WeeklyReport.objects.filter(student=self.student).count(), 1)
+        self.assertEqual(
+            WeeklyReport.objects.filter(student=self.student).count(), 1
+        )
         self.assertFalse(Box.objects.filter(name="جلسه مشاوره").exists())
-        self.assertTrue(Box.objects.filter(name="نسخه دوم ایونت", is_default=False).exists())
+        self.assertTrue(
+            Box.objects.filter(name="نسخه دوم ایونت", is_default=False).exists()
+        )
 
     def test_invalid_day_is_rejected_instead_of_saved_as_saturday(self):
         response = self.client.post(
@@ -181,7 +261,11 @@ class PlanRuntimeRegressionTests(TestCase):
                     "week_start": "2038-02-01",
                     "week_end": "2038-02-07",
                     "days": [
-                        {"day": "روز نامعتبر", "disabled": False, "tasks": []}
+                        {
+                            "day": "روز نامعتبر",
+                            "disabled": False,
+                            "tasks": [],
+                        }
                     ],
                 }
             ),
@@ -221,7 +305,9 @@ class PlanRuntimeRegressionTests(TestCase):
             data=json.dumps(source_payload),
             content_type="application/json",
         )
-        self.assertEqual(source_response.status_code, 200, source_response.content)
+        self.assertEqual(
+            source_response.status_code, 200, source_response.content
+        )
 
         copy_response = self.client.post(
             "/copy_day_plan/",

--- a/plans/urls.py
+++ b/plans/urls.py
@@ -1,7 +1,7 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from . import lesson_catalog, plan_page, weekly_plans
+from . import lesson_catalog, plan_page, weekly_plans_v2
 from .views import *
 
 
@@ -14,11 +14,11 @@ urlpatterns = [
     path('plan/', plan_page.plan_view, name='plan'),
     path('move-lesson-to-end/', lesson_catalog.move_lesson_to_end, name='move_lesson_to_end'),
     path('get-chapters/', get_chapters, name='get-chapters'),
-    path('save-weekly-report/', weekly_plans.save_weekly_report, name='save_weekly_report'),
-    path('get-weekly-report-details/', weekly_plans.get_weekly_report_details, name='get_weekly_report_details'),
+    path('save-weekly-report/', weekly_plans_v2.save_weekly_report, name='save_weekly_report'),
+    path('get-weekly-report-details/', weekly_plans_v2.get_weekly_report_details, name='get_weekly_report_details'),
     path('update-lesson-order/', update_lesson_order, name='update_lesson_order'),
-    path('check-weekly-report/', weekly_plans.check_weekly_report, name='check_weekly_report'),
-    path('copy_day_plan/', weekly_plans.copy_day_plan, name='copy_day_plan'),
+    path('check-weekly-report/', weekly_plans_v2.check_weekly_report, name='check_weekly_report'),
+    path('copy_day_plan/', weekly_plans_v2.copy_day_plan, name='copy_day_plan'),
     path('get_default_boxes/', lesson_catalog.get_default_boxes, name='get_default_boxes'),
     path('get_default_events/', lesson_catalog.get_default_events, name='get_default_events'),
     path('get-lessons-for-student/', lesson_catalog.get_lessons_for_student, name='get_lessons_for_student'),

--- a/plans/urls.py
+++ b/plans/urls.py
@@ -1,24 +1,24 @@
-from django.urls import path, include
-from .views import *
-from . import lesson_catalog
+from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
+from . import lesson_catalog, plan_page, weekly_plans
+from .views import *
 
-# ساخت یک روتر برای ثبت خودکار URL ها برای ViewSet ها
+
 router = DefaultRouter()
 router.register(r'courses', CourseViewSet, basename='course')
 router.register(r'sessions', SessionViewSet, basename='session')
 
 
 urlpatterns = [
-    path('plan/', lesson_catalog.plan_view, name='plan'),
+    path('plan/', plan_page.plan_view, name='plan'),
     path('move-lesson-to-end/', lesson_catalog.move_lesson_to_end, name='move_lesson_to_end'),
     path('get-chapters/', get_chapters, name='get-chapters'),
-    path('save-weekly-report/', save_weekly_report, name='save_weekly_report'),
-    path('get-weekly-report-details/', get_weekly_report_details, name='get_weekly_report_details'),
+    path('save-weekly-report/', weekly_plans.save_weekly_report, name='save_weekly_report'),
+    path('get-weekly-report-details/', weekly_plans.get_weekly_report_details, name='get_weekly_report_details'),
     path('update-lesson-order/', update_lesson_order, name='update_lesson_order'),
-    path('check-weekly-report/', check_weekly_report, name='check_weekly_report'),
-    path('copy_day_plan/', copy_day_plan, name='copy_day_plan'),
+    path('check-weekly-report/', weekly_plans.check_weekly_report, name='check_weekly_report'),
+    path('copy_day_plan/', weekly_plans.copy_day_plan, name='copy_day_plan'),
     path('get_default_boxes/', lesson_catalog.get_default_boxes, name='get_default_boxes'),
     path('get_default_events/', lesson_catalog.get_default_events, name='get_default_events'),
     path('get-lessons-for-student/', lesson_catalog.get_lessons_for_student, name='get_lessons_for_student'),

--- a/plans/weekly_plans.py
+++ b/plans/weekly_plans.py
@@ -1,0 +1,574 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from typing import Any
+
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.http import HttpRequest, HttpResponseBadRequest, JsonResponse
+from django.utils import timezone
+from django.utils.dateparse import parse_date, parse_datetime, parse_time
+from django.views.decorators.http import require_GET, require_POST
+
+from accounts.models import Advisor, Profile, Student
+from plans.models import Box, BoxType, Chapter, Lesson, WeeklyReport, WeeklyReportDetail
+
+
+CANONICAL_DAYS = (
+    "شنبه",
+    "یک‌شنبه",
+    "دوشنبه",
+    "سه‌شنبه",
+    "چهارشنبه",
+    "پنج‌شنبه",
+    "جمعه",
+)
+DAY_OFFSETS = {name: index for index, name in enumerate(CANONICAL_DAYS)}
+
+
+def _day_key(value: object) -> str:
+    return (
+        str(value or "")
+        .strip()
+        .replace("\u200c", "")
+        .replace("\u200e", "")
+        .replace("\u200f", "")
+        .replace(" ", "")
+        .replace("ي", "ی")
+        .replace("ى", "ی")
+        .replace("ك", "ک")
+    )
+
+
+DAY_ALIASES = {_day_key(day): day for day in CANONICAL_DAYS}
+
+
+def normalize_day_name(value: object) -> str | None:
+    return DAY_ALIASES.get(_day_key(value))
+
+
+def _request_profile(request: HttpRequest) -> Profile | None:
+    try:
+        return request.user.profile
+    except (AttributeError, Profile.DoesNotExist):
+        return None
+
+
+def _can_access_student(request: HttpRequest, student: Student) -> bool:
+    if request.user.is_staff:
+        return True
+
+    profile = _request_profile(request)
+    if profile is None:
+        return False
+    if profile.role == "student":
+        return student.profile_id == profile.pk
+    if profile.role == "advisor":
+        return Advisor.objects.filter(profile=profile, student=student).exists()
+    return False
+
+
+def _student_or_response(request: HttpRequest, student_id: object):
+    if not student_id:
+        return None, JsonResponse({"status": "error", "message": "دانش‌آموز انتخاب نشده است."}, status=400)
+    try:
+        student = Student.objects.select_related("profile", "advisor__profile").get(pk=student_id)
+    except (Student.DoesNotExist, TypeError, ValueError):
+        return None, JsonResponse({"status": "error", "message": "دانش‌آموز پیدا نشد."}, status=404)
+    if not _can_access_student(request, student):
+        return None, JsonResponse({"status": "error", "message": "دسترسی به این دانش‌آموز مجاز نیست."}, status=403)
+    return student, None
+
+
+def _parse_date_value(value: object) -> dt.date | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+
+    parsed_date = parse_date(raw)
+    if parsed_date is not None:
+        return parsed_date
+
+    parsed_datetime = parse_datetime(raw)
+    if parsed_datetime is None:
+        return None
+    if timezone.is_aware(parsed_datetime):
+        parsed_datetime = timezone.localtime(parsed_datetime)
+    return parsed_datetime.date()
+
+
+def _midnight(value: dt.date) -> dt.datetime:
+    naive = dt.datetime.combine(value, dt.time.min)
+    return timezone.make_aware(naive, timezone.get_current_timezone())
+
+
+def _parse_clock(value: object) -> dt.time | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    parsed = parse_time(raw)
+    if parsed is not None:
+        return parsed.replace(tzinfo=None)
+    for fmt in ("%H:%M", "%H:%M:%S"):
+        try:
+            return dt.datetime.strptime(raw, fmt).time()
+        except ValueError:
+            continue
+    return None
+
+
+def _report_covering(student: Student, selected_date: dt.date) -> WeeklyReport | None:
+    return (
+        WeeklyReport.objects.filter(
+            student=student,
+            week_start__date__lte=selected_date,
+            week_end__date__gte=selected_date,
+        )
+        .order_by("-week_start")
+        .first()
+    )
+
+
+def _append_report_log(
+    report: WeeklyReport,
+    action: str,
+    data: dict[str, Any] | None,
+    *,
+    request: HttpRequest,
+) -> None:
+    logs = list(report.logs or [])
+    logs.append(
+        {
+            "timestamp": timezone.now().isoformat(),
+            "action": action,
+            "user": {
+                "id": request.user.pk,
+                "username": request.user.get_username(),
+            },
+            "data": data or {},
+        }
+    )
+    report.logs = logs
+
+
+def _serialize_detail(detail: WeeklyReportDetail) -> dict[str, Any]:
+    box = detail.box
+    lesson = box.lesson
+    chapter = box.chapter
+    return {
+        "id": detail.pk,
+        "box_type": box.box_type.name,
+        "title": box.name or (lesson.name if lesson else ""),
+        "lesson_id": lesson.pk if lesson else None,
+        "lesson_name": lesson.name if lesson else None,
+        "lesson_type": lesson.lesson_type.name if lesson and lesson.lesson_type_id else "",
+        "grade": lesson.grade_id if lesson else None,
+        "chapter_id": chapter.pk if chapter else None,
+        "chapter_text": (
+            f"{chapter.chapter_number} - {chapter.name}" if chapter else ""
+        ),
+        "optional_tests_count": box.optional_tests_count or 0,
+        "extra": box.optional_tests_count or 0,
+        "duration_minutes": box.duration_minutes or int(
+            (detail.end_time - detail.start_time).total_seconds() // 60
+        ),
+        "start_time": detail.start_time.isoformat(),
+        "end_time": detail.end_time.isoformat(),
+        "date": timezone.localtime(detail.start_time).date().isoformat()
+        if timezone.is_aware(detail.start_time)
+        else detail.start_time.date().isoformat(),
+        "day_of_week": normalize_day_name(detail.day_of_week) or detail.day_of_week,
+        "is_disabled": detail.is_disabled,
+    }
+
+
+@login_required
+@require_GET
+def check_weekly_report(request: HttpRequest):
+    selected_date = _parse_date_value(request.GET.get("selected_date"))
+    if selected_date is None:
+        return HttpResponseBadRequest("Invalid selected_date.")
+
+    student, error = _student_or_response(request, request.GET.get("student_id"))
+    if error:
+        return error
+
+    report = _report_covering(student, selected_date)
+    if report is not None:
+        return JsonResponse(
+            {
+                "exists": "current",
+                "report_id": report.pk,
+                "week_start": report.week_start.date().isoformat(),
+                "week_end": report.week_end.date().isoformat(),
+            }
+        )
+
+    future = (
+        WeeklyReport.objects.filter(student=student, week_start__date__gt=selected_date)
+        .order_by("week_start")
+        .first()
+    )
+    if future is not None:
+        return JsonResponse(
+            {
+                "exists": "future",
+                "report_id": future.pk,
+                "week_start": future.week_start.date().isoformat(),
+                "week_end": future.week_end.date().isoformat(),
+            }
+        )
+    return JsonResponse({"exists": False})
+
+
+@login_required
+@require_GET
+def get_weekly_report_details(request: HttpRequest):
+    selected_date = _parse_date_value(request.GET.get("week_start"))
+    if selected_date is None:
+        return HttpResponseBadRequest("Invalid week_start.")
+
+    student, error = _student_or_response(request, request.GET.get("student_id"))
+    if error:
+        return error
+
+    report = (
+        WeeklyReport.objects.filter(student=student, week_start__date=selected_date)
+        .order_by("-week_start")
+        .first()
+    ) or _report_covering(student, selected_date)
+
+    if report is None:
+        return JsonResponse(
+            {
+                "report_id": None,
+                "week_start": selected_date.isoformat(),
+                "week_end": (selected_date + dt.timedelta(days=6)).isoformat(),
+                "important_events": "",
+                "disabled_days": [],
+                "tasks": [],
+            }
+        )
+
+    details = (
+        WeeklyReportDetail.objects.filter(report=report)
+        .select_related(
+            "box__box_type",
+            "box__lesson__lesson_type",
+            "box__lesson__grade",
+            "box__chapter",
+        )
+        .order_by("start_time", "pk")
+    )
+    disabled_days = [
+        normalize_day_name(day) or day
+        for day in (report.disabled_days or "").split(",")
+        if day.strip()
+    ]
+    _append_report_log(
+        report,
+        "Load Weekly Report",
+        {"selected_date": selected_date.isoformat()},
+        request=request,
+    )
+    report.save(update_fields=["logs"])
+
+    return JsonResponse(
+        {
+            "report_id": report.pk,
+            "week_start": report.week_start.date().isoformat(),
+            "week_end": report.week_end.date().isoformat(),
+            "important_events": report.important_events or "",
+            "disabled_days": disabled_days,
+            "tasks": [_serialize_detail(detail) for detail in details],
+        }
+    )
+
+
+def _lesson_and_chapter(task: dict[str, Any]):
+    lesson_id = task.get("lesson_id")
+    chapter_id = task.get("chapter_id")
+    lesson = None
+    chapter = None
+
+    if lesson_id:
+        lesson = Lesson.objects.select_related("grade", "lesson_type").get(pk=lesson_id)
+    if chapter_id:
+        chapter = Chapter.objects.get(pk=chapter_id)
+        if lesson is None or chapter.lesson_id != lesson.pk:
+            raise ValueError("فصل انتخاب‌شده متعلق به این درس نیست.")
+    return lesson, chapter
+
+
+@login_required
+@require_POST
+def save_weekly_report(request: HttpRequest):
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"status": "error", "message": "JSON نامعتبر است."}, status=400)
+
+    student, error = _student_or_response(request, payload.get("student_id"))
+    if error:
+        return error
+
+    week_start_date = _parse_date_value(payload.get("week_start"))
+    week_end_date = _parse_date_value(payload.get("week_end"))
+    if week_start_date is None or week_end_date is None:
+        return JsonResponse({"status": "error", "message": "تاریخ شروع یا پایان هفته نامعتبر است."}, status=400)
+    if week_end_date < week_start_date:
+        return JsonResponse({"status": "error", "message": "پایان هفته قبل از شروع هفته است."}, status=400)
+    if (week_end_date - week_start_date).days > 7:
+        return JsonResponse({"status": "error", "message": "بازه برنامه بیشتر از یک هفته است."}, status=400)
+
+    raw_days = payload.get("days")
+    if not isinstance(raw_days, list):
+        return JsonResponse({"status": "error", "message": "ساختار روزهای برنامه نامعتبر است."}, status=400)
+
+    normalized_days: list[tuple[str, bool, list[dict[str, Any]]]] = []
+    for raw_day in raw_days:
+        if not isinstance(raw_day, dict):
+            return JsonResponse({"status": "error", "message": "ساختار یکی از روزها نامعتبر است."}, status=400)
+        day_name = normalize_day_name(raw_day.get("day"))
+        if day_name is None:
+            return JsonResponse({"status": "error", "message": f"نام روز نامعتبر است: {raw_day.get('day', '')}"}, status=400)
+        tasks = raw_day.get("tasks") or []
+        if not isinstance(tasks, list):
+            return JsonResponse({"status": "error", "message": f"تسک‌های {day_name} نامعتبر است."}, status=400)
+        normalized_days.append((day_name, bool(raw_day.get("disabled")), tasks))
+
+    try:
+        with transaction.atomic():
+            report = (
+                WeeklyReport.objects.select_for_update()
+                .filter(student=student, week_start__date=week_start_date)
+                .first()
+            )
+            created = report is None
+            if report is None:
+                report = WeeklyReport(student=student, week_start=_midnight(week_start_date))
+
+            report.week_end = _midnight(week_end_date) + dt.timedelta(hours=23, minutes=59, seconds=59)
+            report.disabled_days = ",".join(
+                day_name for day_name, disabled, _tasks in normalized_days if disabled
+            )
+            report.important_events = str(payload.get("important_events") or "")
+            _append_report_log(
+                report,
+                "Report created" if created else "Report updated",
+                {
+                    "week_start": week_start_date.isoformat(),
+                    "week_end": week_end_date.isoformat(),
+                },
+                request=request,
+            )
+            report.save()
+
+            old_box_ids = list(report.details.values_list("box_id", flat=True))
+            report.details.all().delete()
+            if old_box_ids:
+                Box.objects.filter(pk__in=old_box_ids, is_default=False).delete()
+
+            box_types: dict[str, BoxType] = {}
+            created_count = 0
+            for day_name, is_disabled, tasks in normalized_days:
+                box_date = week_start_date + dt.timedelta(days=DAY_OFFSETS[day_name])
+                for task in tasks:
+                    if not isinstance(task, dict):
+                        raise ValueError(f"ساختار یک باکس در {day_name} نامعتبر است.")
+
+                    start_clock = _parse_clock(task.get("start"))
+                    end_clock = _parse_clock(task.get("end"))
+                    if start_clock is None or end_clock is None:
+                        raise ValueError(f"زمان یک باکس در {day_name} نامعتبر است.")
+
+                    start_datetime = _midnight(box_date).replace(
+                        hour=start_clock.hour,
+                        minute=start_clock.minute,
+                        second=start_clock.second,
+                    )
+                    end_datetime = _midnight(box_date).replace(
+                        hour=end_clock.hour,
+                        minute=end_clock.minute,
+                        second=end_clock.second,
+                    )
+                    if end_datetime <= start_datetime:
+                        end_datetime += dt.timedelta(days=1)
+
+                    duration_minutes = int(
+                        (end_datetime - start_datetime).total_seconds() // 60
+                    )
+                    if duration_minutes <= 0 or duration_minutes > 24 * 60:
+                        raise ValueError(f"مدت یک باکس در {day_name} معتبر نیست.")
+
+                    box_type_name = str(task.get("box_type") or "مطالعه").strip()
+                    if box_type_name not in {"مطالعه", "ایونت", "تکلیف", "شناور"}:
+                        raise ValueError(f"نوع باکس نامعتبر است: {box_type_name}")
+                    box_type = box_types.get(box_type_name)
+                    if box_type is None:
+                        box_type, _ = BoxType.objects.get_or_create(name=box_type_name)
+                        box_types[box_type_name] = box_type
+
+                    lesson = None
+                    chapter = None
+                    if box_type_name == "مطالعه":
+                        lesson, chapter = _lesson_and_chapter(task)
+
+                    optional_tests_count = task.get("optional_tests_count") or 0
+                    try:
+                        optional_tests_count = max(int(optional_tests_count), 0)
+                    except (TypeError, ValueError):
+                        optional_tests_count = 0
+
+                    title = str(task.get("title") or "").strip()
+                    if not title:
+                        title = lesson.name if lesson else box_type_name
+
+                    box = Box.objects.create(
+                        box_type=box_type,
+                        lesson=lesson,
+                        chapter=chapter,
+                        optional_tests_count=optional_tests_count,
+                        duration_minutes=duration_minutes,
+                        name=title,
+                        is_default=False,
+                    )
+                    WeeklyReportDetail.objects.create(
+                        report=report,
+                        box=box,
+                        start_time=start_datetime,
+                        end_time=end_datetime,
+                        day_of_week=day_name,
+                        is_disabled=is_disabled,
+                    )
+                    created_count += 1
+
+            _append_report_log(
+                report,
+                "Report details saved",
+                {"days_count": len(normalized_days), "tasks_count": created_count},
+                request=request,
+            )
+            report.save(update_fields=["logs"])
+    except (Lesson.DoesNotExist, Chapter.DoesNotExist):
+        return JsonResponse({"status": "error", "message": "درس یا فصل انتخاب‌شده پیدا نشد."}, status=400)
+    except (ValueError, BoxType.DoesNotExist) as exc:
+        return JsonResponse({"status": "error", "message": str(exc)}, status=400)
+
+    return JsonResponse(
+        {
+            "status": "success",
+            "report_id": report.pk,
+            "tasks_count": created_count,
+            "week_start": week_start_date.isoformat(),
+            "week_end": week_end_date.isoformat(),
+        }
+    )
+
+
+@login_required
+@require_POST
+def copy_day_plan(request: HttpRequest):
+    source_student, source_error = _student_or_response(
+        request, request.POST.get("source_student_id")
+    )
+    if source_error:
+        return source_error
+    target_student, target_error = _student_or_response(
+        request, request.POST.get("target_student_id")
+    )
+    if target_error:
+        return target_error
+
+    source_date = _parse_date_value(request.POST.get("source_date"))
+    target_day = normalize_day_name(request.POST.get("target_day_of_week"))
+    if source_date is None or target_day is None:
+        return JsonResponse({"status": "error", "message": "تاریخ یا روز مقصد نامعتبر است."}, status=400)
+
+    source_report = _report_covering(source_student, source_date)
+    if source_report is None:
+        return JsonResponse({"status": "error", "message": "برای روز مبدا برنامه‌ای پیدا نشد."}, status=404)
+
+    source_day = CANONICAL_DAYS[(source_date - source_report.week_start.date()).days % 7]
+    source_details = list(
+        source_report.details.filter(day_of_week__in={source_day, source_day.replace("\u200c", "")})
+        .select_related("box__box_type", "box__lesson", "box__chapter")
+        .order_by("start_time", "pk")
+    )
+    if not source_details:
+        return JsonResponse({"status": "error", "message": "روز مبدا باکسی ندارد."}, status=404)
+
+    target_week_start = source_report.week_start.date()
+    target_date = target_week_start + dt.timedelta(days=DAY_OFFSETS[target_day])
+
+    with transaction.atomic():
+        target_report = (
+            WeeklyReport.objects.select_for_update()
+            .filter(student=target_student, week_start__date=target_week_start)
+            .first()
+        )
+        if target_report is None:
+            target_report = WeeklyReport.objects.create(
+                student=target_student,
+                week_start=_midnight(target_week_start),
+                week_end=_midnight(target_week_start + dt.timedelta(days=6))
+                + dt.timedelta(hours=23, minutes=59, seconds=59),
+                disabled_days="",
+                important_events="",
+                logs=[],
+            )
+
+        old_box_ids = list(
+            target_report.details.filter(
+                day_of_week__in={target_day, target_day.replace("\u200c", "")}
+            ).values_list("box_id", flat=True)
+        )
+        target_report.details.filter(
+            day_of_week__in={target_day, target_day.replace("\u200c", "")}
+        ).delete()
+        if old_box_ids:
+            Box.objects.filter(pk__in=old_box_ids, is_default=False).delete()
+
+        for detail in source_details:
+            source_box = detail.box
+            copied_box = Box.objects.create(
+                box_type=source_box.box_type,
+                lesson=source_box.lesson,
+                chapter=source_box.chapter,
+                optional_tests_count=source_box.optional_tests_count,
+                duration_minutes=source_box.duration_minutes,
+                name=source_box.name,
+                is_default=False,
+            )
+            duration = detail.end_time - detail.start_time
+            start_time = detail.start_time.timetz().replace(tzinfo=None)
+            copied_start = _midnight(target_date).replace(
+                hour=start_time.hour,
+                minute=start_time.minute,
+                second=start_time.second,
+            )
+            WeeklyReportDetail.objects.create(
+                report=target_report,
+                box=copied_box,
+                start_time=copied_start,
+                end_time=copied_start + duration,
+                day_of_week=target_day,
+                is_disabled=False,
+            )
+
+        _append_report_log(
+            target_report,
+            "Copied day plan",
+            {
+                "source_student_id": source_student.pk,
+                "source_date": source_date.isoformat(),
+                "target_day": target_day,
+            },
+            request=request,
+        )
+        target_report.save(update_fields=["logs"])
+
+    return JsonResponse(
+        {"status": "success", "copied_details_count": len(source_details)}
+    )

--- a/plans/weekly_plans_v2.py
+++ b/plans/weekly_plans_v2.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+from typing import Any
+
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.http import HttpRequest, JsonResponse
+from django.views.decorators.http import require_POST
+
+from plans.models import Box, BoxType, Chapter, Lesson, WeeklyReport, WeeklyReportDetail
+from plans.weekly_plans import (
+    _append_report_log,
+    _midnight,
+    _parse_clock,
+    _parse_date_value,
+    _report_covering,
+    _student_or_response,
+    check_weekly_report,
+    get_weekly_report_details,
+    normalize_day_name,
+)
+
+
+DAY_TO_PY_WEEKDAY = {
+    "شنبه": 5,
+    "یک‌شنبه": 6,
+    "دوشنبه": 0,
+    "سه‌شنبه": 1,
+    "چهارشنبه": 2,
+    "پنج‌شنبه": 3,
+    "جمعه": 4,
+}
+PY_WEEKDAY_TO_DAY = {weekday: day for day, weekday in DAY_TO_PY_WEEKDAY.items()}
+ALLOWED_BOX_TYPES = {"مطالعه", "ایونت", "تکلیف", "شناور"}
+
+
+def date_for_day(week_start: dt.date, day_name: str) -> dt.date:
+    """Return the matching calendar date inside the selected seven-day period.
+
+    The Plan page permits any selected start date. Therefore day names must be
+    resolved relative to that start date rather than assuming Saturday is
+    always offset zero.
+    """
+
+    canonical_day = normalize_day_name(day_name)
+    if canonical_day is None:
+        raise ValueError(f"نام روز نامعتبر است: {day_name}")
+    offset = (DAY_TO_PY_WEEKDAY[canonical_day] - week_start.weekday()) % 7
+    return week_start + dt.timedelta(days=offset)
+
+
+def _lesson_and_chapter(task: dict[str, Any]):
+    lesson_id = task.get("lesson_id")
+    chapter_id = task.get("chapter_id")
+    if not lesson_id:
+        raise ValueError("برای باکس مطالعه، انتخاب درس الزامی است.")
+
+    lesson = Lesson.objects.select_related("grade", "lesson_type").get(pk=lesson_id)
+    chapter = None
+    if chapter_id:
+        chapter = Chapter.objects.get(pk=chapter_id)
+        if chapter.lesson_id != lesson.pk:
+            raise ValueError("فصل انتخاب‌شده متعلق به این درس نیست.")
+    return lesson, chapter
+
+
+def _normalized_days(payload: dict[str, Any]):
+    raw_days = payload.get("days")
+    if not isinstance(raw_days, list):
+        raise ValueError("ساختار روزهای برنامه نامعتبر است.")
+
+    normalized: list[tuple[str, bool, list[dict[str, Any]]]] = []
+    seen_days: set[str] = set()
+    for raw_day in raw_days:
+        if not isinstance(raw_day, dict):
+            raise ValueError("ساختار یکی از روزها نامعتبر است.")
+        day_name = normalize_day_name(raw_day.get("day"))
+        if day_name is None:
+            raise ValueError(f"نام روز نامعتبر است: {raw_day.get('day', '')}")
+        if day_name in seen_days:
+            raise ValueError(f"روز {day_name} بیش از یک بار ارسال شده است.")
+        seen_days.add(day_name)
+
+        tasks = raw_day.get("tasks") or []
+        if not isinstance(tasks, list):
+            raise ValueError(f"تسک‌های {day_name} نامعتبر است.")
+        normalized.append((day_name, bool(raw_day.get("disabled")), tasks))
+    return normalized
+
+
+@login_required
+@require_POST
+def save_weekly_report(request: HttpRequest):
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return JsonResponse(
+            {"status": "error", "message": "JSON نامعتبر است."}, status=400
+        )
+
+    student, error = _student_or_response(request, payload.get("student_id"))
+    if error:
+        return error
+
+    week_start_date = _parse_date_value(payload.get("week_start"))
+    week_end_date = _parse_date_value(payload.get("week_end"))
+    if week_start_date is None or week_end_date is None:
+        return JsonResponse(
+            {
+                "status": "error",
+                "message": "تاریخ شروع یا پایان هفته نامعتبر است.",
+            },
+            status=400,
+        )
+    if week_end_date < week_start_date:
+        return JsonResponse(
+            {"status": "error", "message": "پایان هفته قبل از شروع هفته است."},
+            status=400,
+        )
+    if (week_end_date - week_start_date).days != 6:
+        return JsonResponse(
+            {"status": "error", "message": "بازه برنامه باید دقیقاً هفت روز باشد."},
+            status=400,
+        )
+
+    try:
+        normalized_days = _normalized_days(payload)
+    except ValueError as exc:
+        return JsonResponse(
+            {"status": "error", "message": str(exc)}, status=400
+        )
+
+    try:
+        with transaction.atomic():
+            report = (
+                WeeklyReport.objects.select_for_update()
+                .filter(student=student, week_start__date=week_start_date)
+                .first()
+            )
+            created = report is None
+            if report is None:
+                report = WeeklyReport(
+                    student=student,
+                    week_start=_midnight(week_start_date),
+                )
+
+            report.week_end = _midnight(week_end_date) + dt.timedelta(
+                hours=23, minutes=59, seconds=59
+            )
+            report.disabled_days = ",".join(
+                day_name
+                for day_name, disabled, _tasks in normalized_days
+                if disabled
+            )
+            report.important_events = str(payload.get("important_events") or "")
+            _append_report_log(
+                report,
+                "Report created" if created else "Report updated",
+                {
+                    "week_start": week_start_date.isoformat(),
+                    "week_end": week_end_date.isoformat(),
+                },
+                request=request,
+            )
+            report.save()
+
+            old_box_ids = list(report.details.values_list("box_id", flat=True))
+            report.details.all().delete()
+            if old_box_ids:
+                Box.objects.filter(pk__in=old_box_ids, is_default=False).delete()
+
+            box_types: dict[str, BoxType] = {}
+            created_count = 0
+            for day_name, is_disabled, tasks in normalized_days:
+                box_date = date_for_day(week_start_date, day_name)
+                if box_date > week_end_date:
+                    raise ValueError(
+                        f"روز {day_name} خارج از بازه انتخاب‌شده قرار گرفته است."
+                    )
+
+                for task in tasks:
+                    if not isinstance(task, dict):
+                        raise ValueError(
+                            f"ساختار یک باکس در {day_name} نامعتبر است."
+                        )
+
+                    start_clock = _parse_clock(task.get("start"))
+                    end_clock = _parse_clock(task.get("end"))
+                    if start_clock is None or end_clock is None:
+                        raise ValueError(
+                            f"زمان یک باکس در {day_name} نامعتبر است."
+                        )
+
+                    start_datetime = _midnight(box_date).replace(
+                        hour=start_clock.hour,
+                        minute=start_clock.minute,
+                        second=start_clock.second,
+                    )
+                    end_datetime = _midnight(box_date).replace(
+                        hour=end_clock.hour,
+                        minute=end_clock.minute,
+                        second=end_clock.second,
+                    )
+                    if end_datetime <= start_datetime:
+                        end_datetime += dt.timedelta(days=1)
+
+                    duration_minutes = int(
+                        (end_datetime - start_datetime).total_seconds() // 60
+                    )
+                    if duration_minutes <= 0 or duration_minutes > 24 * 60:
+                        raise ValueError(
+                            f"مدت یک باکس در {day_name} معتبر نیست."
+                        )
+
+                    box_type_name = str(
+                        task.get("box_type") or "مطالعه"
+                    ).strip()
+                    if box_type_name not in ALLOWED_BOX_TYPES:
+                        raise ValueError(
+                            f"نوع باکس نامعتبر است: {box_type_name}"
+                        )
+                    box_type = box_types.get(box_type_name)
+                    if box_type is None:
+                        box_type, _ = BoxType.objects.get_or_create(
+                            name=box_type_name
+                        )
+                        box_types[box_type_name] = box_type
+
+                    lesson = None
+                    chapter = None
+                    if box_type_name == "مطالعه":
+                        lesson, chapter = _lesson_and_chapter(task)
+
+                    optional_tests_count = task.get(
+                        "optional_tests_count"
+                    ) or 0
+                    try:
+                        optional_tests_count = max(
+                            int(optional_tests_count), 0
+                        )
+                    except (TypeError, ValueError):
+                        optional_tests_count = 0
+
+                    title = str(task.get("title") or "").strip()
+                    if not title:
+                        title = lesson.name if lesson else box_type_name
+
+                    box = Box.objects.create(
+                        box_type=box_type,
+                        lesson=lesson,
+                        chapter=chapter,
+                        optional_tests_count=optional_tests_count,
+                        duration_minutes=duration_minutes,
+                        name=title,
+                        is_default=False,
+                    )
+                    WeeklyReportDetail.objects.create(
+                        report=report,
+                        box=box,
+                        start_time=start_datetime,
+                        end_time=end_datetime,
+                        day_of_week=day_name,
+                        is_disabled=is_disabled,
+                    )
+                    created_count += 1
+
+            _append_report_log(
+                report,
+                "Report details saved",
+                {
+                    "days_count": len(normalized_days),
+                    "tasks_count": created_count,
+                },
+                request=request,
+            )
+            report.save(update_fields=["logs"])
+    except (Lesson.DoesNotExist, Chapter.DoesNotExist):
+        return JsonResponse(
+            {
+                "status": "error",
+                "message": "درس یا فصل انتخاب‌شده پیدا نشد.",
+            },
+            status=400,
+        )
+    except (ValueError, BoxType.DoesNotExist) as exc:
+        return JsonResponse(
+            {"status": "error", "message": str(exc)}, status=400
+        )
+
+    return JsonResponse(
+        {
+            "status": "success",
+            "report_id": report.pk,
+            "tasks_count": created_count,
+            "week_start": week_start_date.isoformat(),
+            "week_end": week_end_date.isoformat(),
+        }
+    )
+
+
+@login_required
+@require_POST
+def copy_day_plan(request: HttpRequest):
+    source_student, source_error = _student_or_response(
+        request, request.POST.get("source_student_id")
+    )
+    if source_error:
+        return source_error
+    target_student, target_error = _student_or_response(
+        request, request.POST.get("target_student_id")
+    )
+    if target_error:
+        return target_error
+
+    source_date = _parse_date_value(request.POST.get("source_date"))
+    target_day = normalize_day_name(request.POST.get("target_day_of_week"))
+    if source_date is None or target_day is None:
+        return JsonResponse(
+            {
+                "status": "error",
+                "message": "تاریخ یا روز مقصد نامعتبر است.",
+            },
+            status=400,
+        )
+
+    source_report = _report_covering(source_student, source_date)
+    if source_report is None:
+        return JsonResponse(
+            {
+                "status": "error",
+                "message": "برای روز مبدا برنامه‌ای پیدا نشد.",
+            },
+            status=404,
+        )
+
+    source_day = PY_WEEKDAY_TO_DAY[source_date.weekday()]
+    source_day_aliases = {source_day, source_day.replace("\u200c", "")}
+    source_details = list(
+        source_report.details.filter(day_of_week__in=source_day_aliases)
+        .select_related("box__box_type", "box__lesson", "box__chapter")
+        .order_by("start_time", "pk")
+    )
+    if not source_details:
+        return JsonResponse(
+            {"status": "error", "message": "روز مبدا باکسی ندارد."},
+            status=404,
+        )
+
+    target_week_start = source_report.week_start.date()
+    target_week_end = source_report.week_end.date()
+    target_date = date_for_day(target_week_start, target_day)
+    if target_date > target_week_end:
+        return JsonResponse(
+            {
+                "status": "error",
+                "message": "روز مقصد خارج از بازه برنامه است.",
+            },
+            status=400,
+        )
+
+    target_day_aliases = {target_day, target_day.replace("\u200c", "")}
+    with transaction.atomic():
+        target_report = (
+            WeeklyReport.objects.select_for_update()
+            .filter(
+                student=target_student,
+                week_start__date=target_week_start,
+            )
+            .first()
+        )
+        if target_report is None:
+            target_report = WeeklyReport.objects.create(
+                student=target_student,
+                week_start=source_report.week_start,
+                week_end=source_report.week_end,
+                disabled_days="",
+                important_events="",
+                logs=[],
+            )
+
+        old_box_ids = list(
+            target_report.details.filter(
+                day_of_week__in=target_day_aliases
+            ).values_list("box_id", flat=True)
+        )
+        target_report.details.filter(
+            day_of_week__in=target_day_aliases
+        ).delete()
+        if old_box_ids:
+            Box.objects.filter(pk__in=old_box_ids, is_default=False).delete()
+
+        for detail in source_details:
+            source_box = detail.box
+            copied_box = Box.objects.create(
+                box_type=source_box.box_type,
+                lesson=source_box.lesson,
+                chapter=source_box.chapter,
+                optional_tests_count=source_box.optional_tests_count,
+                duration_minutes=source_box.duration_minutes,
+                name=source_box.name,
+                is_default=False,
+            )
+            duration = detail.end_time - detail.start_time
+            start_time = detail.start_time.timetz().replace(tzinfo=None)
+            copied_start = _midnight(target_date).replace(
+                hour=start_time.hour,
+                minute=start_time.minute,
+                second=start_time.second,
+            )
+            WeeklyReportDetail.objects.create(
+                report=target_report,
+                box=copied_box,
+                start_time=copied_start,
+                end_time=copied_start + duration,
+                day_of_week=target_day,
+                is_disabled=False,
+            )
+
+        _append_report_log(
+            target_report,
+            "Copied day plan",
+            {
+                "source_student_id": source_student.pk,
+                "source_date": source_date.isoformat(),
+                "target_day": target_day,
+            },
+            request=request,
+        )
+        target_report.save(update_fields=["logs"])
+
+    return JsonResponse(
+        {
+            "status": "success",
+            "copied_details_count": len(source_details),
+        }
+    )


### PR DESCRIPTION
## مشکل اصلی
کد قدیمی Plan به‌صورت یک فایل HTML بسیار بزرگ با چندین handler هم‌پوشان اجرا می‌شد. هات‌فیکس قبلی parsing صفحه را برگرداند؛ این PR رفتارهای اصلی را در یک Runtime مستقل و قابل تست بازسازی می‌کند.

## رفتارهای بازسازی‌شده
- Load هفته بر اساس تاریخ شمسی و دانش‌آموز انتخاب‌شده
- نگهداری صحیح `week_start` و `week_end` انتخابی در Save
- Drag & Drop ایونت، تکلیف، باکس شناور، آزمون و درس
- جابه‌جایی باکس بین روزها
- Resize روی گرید ۱۵ دقیقه و به‌روزرسانی لحظه‌ای برچسب زمان
- جلوگیری از هم‌پوشانی باکس‌ها
- حذف، تکرار درس در روزهای دیگر و تبدیل ایونت به تکلیف
- استراحت روز و تعطیلی ایونت‌ها با قابلیت بازگردانی
- بارگذاری ایونت‌های پیش‌فرض به‌صورت کاملاً draggable/resizable
- رندر صحیح انواع ذخیره‌شده، شامل `شناور` و `تکلیف`
- بارگذاری درس‌ها و فصل‌ها برای دانش‌آموز انتخاب‌شده
- یکسان‌سازی روزهای هفته با و بدون نیم‌فاصله
- پشتیبانی صحیح از ساعت ۰۰:۰۰ و بازه‌های عبوری از نیمه‌شب

## اصلاح Backend
- APIهای جدید و تراکنشی برای Check/Load/Save/Copy
- حذف fallback خطرناک روز نامعتبر به شنبه
- عدم تبدیل تمام ایونت‌های کاربر به `is_default=True`
- حفظ duration واقعی و نوع باکس
- پاک‌سازی Boxهای یتیم هنگام ویرایش گزارش
- کنترل دسترسی دانش‌آموز/مشاور/ادمین

## جلوگیری از تکرار خرابی
- Runtime فقط پیش از آخرین `</body>` واقعی اضافه می‌شود.
- تست محل اسکریپت در HTML وجود دارد.
- `node --check` برای Syntax جاوااسکریپت اجرا می‌شود.
- تست Django برای Round-trip ذخیره/لود، نیمه‌شب، نیم‌فاصله، Copy Day و انواع باکس اجرا می‌شود.