### PR TITLE
Preserve Plan rollback state during real drag

### DIFF
--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260721-1"
+ASSET_VERSION = "20260721-2"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
 )

--- a/plans/static/plans/plan-interactions.js
+++ b/plans/static/plans/plan-interactions.js
@@ -10,7 +10,7 @@
   const GRID_MINUTES = 15;
   const GRID_PIXELS = GRID_MINUTES * PIXELS_PER_MINUTE;
   const MIN_HEIGHT = GRID_PIXELS;
-  const VERSION = '2026.07.21.1';
+  const VERSION = '2026.07.21.2';
 
   function snap(value) {
     return Math.round(Number(value || 0) / GRID_PIXELS) * GRID_PIXELS;
@@ -197,8 +197,13 @@
       start: function (event, ui) {
         const $current = $(this);
         const offset = $current.offset();
-        $current.data('planOriginalParent', $current.parent());
-        $current.data('planOriginalTop', Number.parseFloat($current.css('top')) || 0);
+        const originalParent = $current.parent();
+        const originalTop = Number.parseFloat($current.css('top')) || 0;
+
+        $current.data('planOriginalParent', originalParent);
+        $current.data('planOriginalTop', originalTop);
+        $current.data('runtimeOriginalParent', originalParent);
+        $current.data('runtimeOriginalTop', originalTop);
         $current.data('planGrabOffsetY', Math.max(0, event.pageY - offset.top));
         $current.data('planDropAccepted', false);
         $current.addClass('plan-dragging-source');
@@ -369,7 +374,14 @@
     $(document)
       .off('mousedown.planInteraction', '.calendar-task')
       .on('mousedown.planInteraction', '.calendar-task', function () {
-        initializeTask($(this));
+        const $task = $(this);
+        if (
+          $task.attr('data-plan-interaction-version') !== VERSION ||
+          !safeInstance($task, 'draggable') ||
+          !safeInstance($task, 'resizable')
+        ) {
+          initializeTask($task);
+        }
       });
 
     synchronize();


### PR DESCRIPTION
اصلاح تکمیلی قبل از نتیجه نهایی:

- ذخیره هم‌زمان state جدید و state مورد انتظار Runtime قدیمی هنگام شروع Drag
- برگشت دقیق باکس به همان parent و همان زمان هنگام overlap یا Drop نامعتبر
- جلوگیری از destroy/recreate شدن Draggable دقیقاً روی mousedown؛ این کار می‌توانست اولین حرکت موس را از دست بدهد
- افزایش نسخه asset برای حذف قطعی cache قبلی مرورگر