### PR TITLE
Make Plan resizing pointer-driven like Google Calendar

### DIFF
--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -31,6 +31,7 @@ jobs:
           node --check plans/static/plans/plan-runtime.js
           node --check plans/static/plans/plan-secondary.js
           node --check plans/static/plans/plan-interactions.js
+          node --check plans/static/plans/plan-manual-resize.js
           python3 -m py_compile \
             deploy/plan_e2e.py \
             deploy/plan_e2e_runner.py \

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260721-2"
+ASSET_VERSION = "20260721-3"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
 )
@@ -14,6 +14,7 @@ RUNTIME_PATHS = (
     ("plans/plan-runtime.js", "data-plan-runtime"),
     ("plans/plan-secondary.js", "data-plan-secondary"),
     ("plans/plan-interactions.js", "data-plan-interactions"),
+    ("plans/plan-manual-resize.js", "data-plan-manual-resize"),
 )
 
 

--- a/plans/static/plans/plan-interactions.css
+++ b/plans/static/plans/plan-interactions.css
@@ -32,6 +32,16 @@
   z-index: 1000 !important;
 }
 
+body.plan-resize-cursor,
+body.plan-resize-cursor * {
+  cursor: ns-resize !important;
+  user-select: none !important;
+}
+
+.calendar-task > .ui-resizable-s:not(.plan-resize-handle) {
+  display: none !important;
+}
+
 .plan-resize-handle {
   position: absolute !important;
   right: 8px !important;

--- a/plans/static/plans/plan-manual-resize.js
+++ b/plans/static/plans/plan-manual-resize.js
@@ -1,0 +1,195 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$ || !$.ui) {
+    return;
+  }
+
+  const PIXELS_PER_MINUTE = 35 / 60;
+  const GRID_MINUTES = 15;
+  const GRID_PIXELS = GRID_MINUTES * PIXELS_PER_MINUTE;
+  const MIN_HEIGHT = GRID_PIXELS;
+  const VERSION = '2026.07.21.1';
+
+  function snap(value) {
+    return Math.round(Number(value || 0) / GRID_PIXELS) * GRID_PIXELS;
+  }
+
+  function updateTime($task) {
+    if (typeof window.updateTimeLabel === 'function') {
+      window.updateTimeLabel($task);
+    }
+    const height = Math.max(MIN_HEIGHT, Number.parseFloat($task.css('height')) || $task.outerHeight());
+    $task.attr('data-duration-minutes', Math.round(height / PIXELS_PER_MINUTE));
+  }
+
+  function overlaps($task, top, height, $container) {
+    const bottom = top + height;
+    let overlap = false;
+    $container.children('.calendar-task:visible').not($task).each(function () {
+      const $other = $(this);
+      const otherTop = Number.parseFloat($other.css('top')) || 0;
+      const otherBottom = otherTop + $other.outerHeight();
+      if (!(bottom <= otherTop || top >= otherBottom)) {
+        overlap = true;
+        return false;
+      }
+    });
+    return overlap;
+  }
+
+  function ensureHandle($task) {
+    let $handle = $task.children('.plan-resize-handle');
+    if (!$handle.length) {
+      $handle = $('<div class="plan-resize-handle" title="برای تغییر زمان بکشید"><span></span></div>');
+      $task.append($handle);
+    }
+    return $handle;
+  }
+
+  function bindPointerResize($task) {
+    const $handle = ensureHandle($task);
+    $handle.off('.planManualResize').on('pointerdown.planManualResize', function (event) {
+      const originalEvent = event.originalEvent;
+      if (window.readOnlyMode || (originalEvent.button !== undefined && originalEvent.button !== 0)) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+
+      const startY = originalEvent.clientY;
+      const startHeight = $task.outerHeight();
+      const top = Number.parseFloat($task.css('top')) || 0;
+      const $container = $task.parent();
+      const maximum = Math.max(MIN_HEIGHT, $container.innerHeight() - top);
+      let finished = false;
+
+      $task.data('planManualResizeOriginalHeight', startHeight);
+      $task.addClass('plan-resizing');
+      $('body').addClass('plan-resize-cursor');
+
+      if (this.setPointerCapture && originalEvent.pointerId !== undefined) {
+        try {
+          this.setPointerCapture(originalEvent.pointerId);
+        } catch (_error) {}
+      }
+
+      function move(moveEvent) {
+        const nativeEvent = moveEvent.originalEvent;
+        const delta = nativeEvent.clientY - startY;
+        const height = Math.max(MIN_HEIGHT, Math.min(snap(startHeight + delta), maximum));
+        $task.css('height', height);
+        updateTime($task);
+        moveEvent.preventDefault();
+      }
+
+      function finish() {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        $(document).off('.planManualResizeActive');
+        $('body').removeClass('plan-resize-cursor');
+
+        const height = Math.max(MIN_HEIGHT, Math.min(snap($task.outerHeight()), maximum));
+        if (overlaps($task, top, height, $container)) {
+          $task.css('height', $task.data('planManualResizeOriginalHeight'));
+        } else {
+          $task.css('height', height);
+        }
+        $task.removeClass('plan-resizing');
+        updateTime($task);
+      }
+
+      $(document)
+        .on('pointermove.planManualResizeActive', move)
+        .on('pointerup.planManualResizeActive pointercancel.planManualResizeActive', finish);
+    });
+  }
+
+  function configureResizableCompatibility($task) {
+    try {
+      if ($task.resizable('instance')) {
+        $task.resizable('destroy');
+      }
+    } catch (_error) {}
+
+    $task.resizable({
+      handles: 's',
+      minHeight: MIN_HEIGHT,
+      autoHide: false,
+      start: function () {
+        const $current = $(this);
+        $current.data('planCompatibilityOriginalHeight', $current.outerHeight());
+      },
+      resize: function (_event, ui) {
+        const $current = $(this);
+        const top = Number.parseFloat($current.css('top')) || 0;
+        const maximum = Math.max(MIN_HEIGHT, $current.parent().innerHeight() - top);
+        const height = Math.max(MIN_HEIGHT, Math.min(snap(ui.size.height), maximum));
+        ui.size.height = height;
+        $current.css('height', height);
+        updateTime($current);
+      },
+      stop: function (_event, ui) {
+        const $current = $(this);
+        const top = Number.parseFloat($current.css('top')) || 0;
+        const maximum = Math.max(MIN_HEIGHT, $current.parent().innerHeight() - top);
+        const height = Math.max(MIN_HEIGHT, Math.min(snap(ui.size.height), maximum));
+        if (overlaps($current, top, height, $current.parent())) {
+          $current.css('height', $current.data('planCompatibilityOriginalHeight'));
+        } else {
+          $current.css('height', height);
+        }
+        updateTime($current);
+      }
+    });
+
+    bindPointerResize($task);
+    $task.attr('data-plan-manual-resize-version', VERSION);
+  }
+
+  function synchronize() {
+    $('.calendar .calendar-task').each(function () {
+      const $task = $(this);
+      if (
+        $task.attr('data-plan-manual-resize-version') !== VERSION ||
+        !$task.children('.plan-resize-handle').length
+      ) {
+        configureResizableCompatibility($task);
+      } else {
+        bindPointerResize($task);
+      }
+    });
+  }
+
+  function initialize() {
+    const previousInit = window.initCalendarTask;
+    if (typeof previousInit === 'function' && !previousInit.planManualResizeWrapped) {
+      const wrappedInit = function ($task) {
+        const result = previousInit($task);
+        window.setTimeout(function () {
+          configureResizableCompatibility($($task));
+        }, 0);
+        return result;
+      };
+      wrappedInit.planManualResizeWrapped = true;
+      window.initCalendarTask = wrappedInit;
+    }
+
+    const calendar = document.querySelector('.calendar');
+    if (calendar) {
+      new MutationObserver(function () {
+        window.requestAnimationFrame(synchronize);
+      }).observe(calendar, { childList: true, subtree: true });
+    }
+
+    synchronize();
+    window.setInterval(synchronize, 400);
+    window.dispatchEvent(new CustomEvent('plan:manual-resize-ready'));
+  }
+
+  $(initialize);
+})(window, document, window.jQuery);

--- a/plans/test_plan_secondary.py
+++ b/plans/test_plan_secondary.py
@@ -25,13 +25,16 @@ class PlanSecondaryScriptTests(TestCase):
         runtime = b'/static/plans/plan-runtime.js?v='
         secondary = b'/static/plans/plan-secondary.js?v='
         interactions = b'/static/plans/plan-interactions.js?v='
+        manual_resize = b'/static/plans/plan-manual-resize.js?v='
 
-        for marker in (style, runtime, secondary, interactions):
+        for marker in (style, runtime, secondary, interactions, manual_resize):
             self.assertEqual(content.count(marker), 1)
 
         self.assertLess(content.index(style), content.index(runtime))
         self.assertLess(content.index(runtime), content.index(secondary))
         self.assertLess(content.index(secondary), content.index(interactions))
-        self.assertLess(content.index(interactions), content.rfind(b"</body>"))
+        self.assertLess(content.index(interactions), content.index(manual_resize))
+        self.assertLess(content.index(manual_resize), content.rfind(b"</body>"))
         self.assertIn(b'data-plan-interactions="true"', content)
+        self.assertIn(b'data-plan-manual-resize="true"', content)
         self.assertIn(b'data-plan-interactions-style="true"', content)


### PR DESCRIPTION
## مشکل واقعی
تست Mouse واقعی نشان داد Drop و جابه‌جایی باکس‌ها درست شده‌اند، اما کشیدن دستگیره پایین هنوز ارتفاع باکس را تغییر نمی‌دهد. علت وابستگی دستگیره سفارشی به lifecycle داخلی jQuery UI Resizable بود.

## اصلاح
- Resize مستقیم با Pointer Events؛ مناسب Mouse، قلم و Touch
- `pointerdown / pointermove / pointerup` روی دستگیره واضح پایین باکس
- تغییر زنده‌ی ارتفاع و ساعت پایان حین کشیدن
- Snap روی گرید ۱۵ دقیقه
- محدودیت به انتهای ستون روز
- جلوگیری از overlap و بازگشت به ارتفاع قبلی
- نگهداری jQuery UI Resizable فقط به‌عنوان لایه سازگاری برای کدهای قدیمی
- لود Runtime Resize در آخرین مرحله تا Handler آن بازنویسی نشود
- Cache bust با نسخه جدید Asset

تست واقعی Production همان سناریویی را دوباره اجرا می‌کند که قبلاً دقیقاً روی افزایش ارتفاع شکست خورده بود.