### PR TITLE
Keep Plan dropdown editor open after pencil click

### DIFF
--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260721-3"
+ASSET_VERSION = "20260721-4"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
 )

--- a/plans/static/plans/plan-interactions.css
+++ b/plans/static/plans/plan-interactions.css
@@ -76,7 +76,8 @@ body.plan-resize-cursor * {
   min-width: 0;
 }
 
-.extended-task.plan-study-editing .task-info {
+.extended-task.plan-study-editing .task-info,
+.extended-task.plan-study-editor-pinned .task-info {
   display: grid !important;
   grid-template-columns: minmax(0, 1fr) minmax(62px, 0.45fr);
   gap: 5px;
@@ -85,17 +86,30 @@ body.plan-resize-cursor * {
   padding-left: 4px;
 }
 
-.extended-task.plan-study-editing .task-info > .time-label {
+.extended-task.plan-study-editing .task-info > .time-label,
+.extended-task.plan-study-editor-pinned .task-info > .time-label {
   grid-column: 1 / -1;
 }
 
-.extended-task.plan-study-editing .task-info > .select2-container {
+.extended-task.plan-study-editing .task-info > .select2-container,
+.extended-task.plan-study-editor-pinned .task-info > .select2-container {
   min-width: 0 !important;
   width: 100% !important;
   margin: 0 !important;
 }
 
-.extended-task.plan-study-editing .select2-selection {
+.extended-task.plan-study-editor-pinned .task-info > .select2-container,
+.extended-task.plan-study-editor-pinned .task-chapter:not(.select2-hidden-accessible),
+.extended-task.plan-study-editor-pinned .task-extra:not(.select2-hidden-accessible) {
+  display: block !important;
+}
+
+.extended-task.plan-study-editor-pinned .plan-study-compact {
+  display: none !important;
+}
+
+.extended-task.plan-study-editing .select2-selection,
+.extended-task.plan-study-editor-pinned .select2-selection {
   min-height: 28px !important;
   height: 28px !important;
   border: 1px solid rgba(100, 116, 139, 0.35) !important;
@@ -104,14 +118,16 @@ body.plan-resize-cursor * {
   box-shadow: none !important;
 }
 
-.extended-task.plan-study-editing .select2-selection__rendered {
+.extended-task.plan-study-editing .select2-selection__rendered,
+.extended-task.plan-study-editor-pinned .select2-selection__rendered {
   line-height: 26px !important;
   padding-right: 7px !important;
   padding-left: 20px !important;
   font-size: 10px !important;
 }
 
-.extended-task.plan-study-editing .select2-selection__arrow {
+.extended-task.plan-study-editing .select2-selection__arrow,
+.extended-task.plan-study-editor-pinned .select2-selection__arrow {
   height: 26px !important;
 }
 

--- a/plans/static/plans/plan-manual-resize.js
+++ b/plans/static/plans/plan-manual-resize.js
@@ -9,7 +9,7 @@
   const GRID_MINUTES = 15;
   const GRID_PIXELS = GRID_MINUTES * PIXELS_PER_MINUTE;
   const MIN_HEIGHT = GRID_PIXELS;
-  const VERSION = '2026.07.21.1';
+  const VERSION = '2026.07.21.2';
 
   function snap(value) {
     return Math.round(Number(value || 0) / GRID_PIXELS) * GRID_PIXELS;
@@ -151,6 +151,42 @@
     $task.attr('data-plan-manual-resize-version', VERSION);
   }
 
+  function openStudyEditor($task) {
+    $task.addClass('plan-study-editor-pinned plan-study-editing');
+    $task.find('.plan-study-compact').hide();
+    $task.find('.task-chapter, .task-extra').each(function () {
+      const $select = $(this);
+      if ($select.hasClass('select2-hidden-accessible')) {
+        $select.next('.select2-container').css('display', 'block');
+      } else {
+        $select.show();
+      }
+    });
+  }
+
+  function bindPersistentStudyEditor() {
+    $(document)
+      .off('click.planPersistentStudyEditor', '.plan-study-edit')
+      .on('click.planPersistentStudyEditor', '.plan-study-edit', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        openStudyEditor($(this).closest('.calendar-task'));
+      })
+      .off('.planPersistentStudyEditorSelection', '.task-chapter, .task-extra')
+      .on(
+        'change.planPersistentStudyEditorSelection select2:select.planPersistentStudyEditorSelection',
+        '.task-chapter, .task-extra',
+        function () {
+          const $task = $(this).closest('.calendar-task');
+          const chapter = String($task.find('.task-chapter').val() || '').trim();
+          const tests = String($task.find('.task-extra').val() || '').trim();
+          if (chapter && tests) {
+            $task.removeClass('plan-study-editor-pinned');
+          }
+        }
+      );
+  }
+
   function synchronize() {
     $('.calendar .calendar-task').each(function () {
       const $task = $(this);
@@ -161,6 +197,10 @@
         configureResizableCompatibility($task);
       } else {
         bindPointerResize($task);
+      }
+
+      if ($task.hasClass('plan-study-editor-pinned')) {
+        openStudyEditor($task);
       }
     });
   }
@@ -178,6 +218,8 @@
       wrappedInit.planManualResizeWrapped = true;
       window.initCalendarTask = wrappedInit;
     }
+
+    bindPersistentStudyEditor();
 
     const calendar = document.querySelector('.calendar');
     if (calendar) {


### PR DESCRIPTION
تست واقعی موس تمام موارد Drag/Move/Resize/Collapse را پاس کرد و فقط این مورد شکست خورد: بعد از کلیک روی مداد، Sync دوره‌ای Runtime فوراً Select2ها را دوباره جمع می‌کرد.

اصلاح:
- حالت `plan-study-editor-pinned` بعد از کلیک مداد
- نمایش اجباری و پایدار دو Select2 تا انتخاب بعدی
- جلوگیری CSS از نمایش مجدد خلاصه در زمان ویرایش
- خروج از حالت pinned بعد از معتبر شدن فصل و تعداد تست
- حفظ رفتار قبلی: بعد از انتخاب هر دو مقدار، Dropdownها جمع و خلاصه + مداد نمایش داده می‌شود
- Cache bust برای JS/CSS جدید