### PR TITLE
Fix dragging around school blocks and remove synthetic 2120 reports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,15 @@ jobs:
           set -euo pipefail
           node --check plans/static/plans/plan-runtime.js
           node --check plans/static/plans/plan-secondary.js
+          node --check plans/static/plans/plan-interactions.js
+          node --check plans/static/plans/plan-manual-resize.js
+          node --check plans/static/plans/plan-drag-surface.js
           python3 -m py_compile \
             deploy/plan_e2e.py \
             deploy/plan_e2e_runner.py \
+            deploy/plan_real_interaction_e2e.py \
+            deploy/plan_school_drag_e2e.py \
+            plans/management/commands/cleanup_plan_demo_reports.py \
             plans/plan_page.py \
             plans/weekly_plans.py \
             plans/weekly_plans_v2.py
@@ -130,6 +136,8 @@ jobs:
                 f'{summary.events_created} events created.'
             )
             PY
+
+            ./venv/bin/python manage.py cleanup_plan_demo_reports
 
       - name: Repair upstream, open ports and verify services
         uses: appleboy/ssh-action@v1.2.5
@@ -270,3 +278,21 @@ jobs:
           .plan-browser-venv/bin/pip install -q playwright
           .plan-browser-venv/bin/python -m playwright install --with-deps chromium
           .plan-browser-venv/bin/python deploy/plan_e2e_runner.py
+
+      - name: Remove synthetic browser-test reports
+        if: always()
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          port: ${{ secrets.SERVER_PORT }}
+          timeout: 60s
+          command_timeout: 5m
+          script: |
+            set -eu
+            set -a
+            . /etc/kimiagarkhune.env
+            set +a
+            cd /var/www/KimiagarKhune
+            ./venv/bin/python manage.py cleanup_plan_demo_reports

--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -8,6 +8,7 @@ on:
       - 'deploy/plan_e2e.py'
       - 'deploy/plan_e2e_runner.py'
       - 'deploy/plan_real_interaction_e2e.py'
+      - 'deploy/plan_school_drag_e2e.py'
       - 'config/test_settings.py'
       - '.github/workflows/deploy.yml'
       - '.github/workflows/validate-plan.yml'
@@ -32,10 +33,13 @@ jobs:
           node --check plans/static/plans/plan-secondary.js
           node --check plans/static/plans/plan-interactions.js
           node --check plans/static/plans/plan-manual-resize.js
+          node --check plans/static/plans/plan-drag-surface.js
           python3 -m py_compile \
             deploy/plan_e2e.py \
             deploy/plan_e2e_runner.py \
             deploy/plan_real_interaction_e2e.py \
+            deploy/plan_school_drag_e2e.py \
+            plans/management/commands/cleanup_plan_demo_reports.py \
             plans/plan_page.py \
             plans/weekly_plans.py \
             plans/weekly_plans_v2.py

--- a/.github/workflows/verify-plan-interactions.yml
+++ b/.github/workflows/verify-plan-interactions.yml
@@ -15,7 +15,7 @@ jobs:
   verify-real-interactions:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
 
     steps:
       - name: Checkout deployed commit
@@ -31,7 +31,7 @@ jobs:
           .plan-real-browser-venv/bin/pip install -q playwright
           .plan-real-browser-venv/bin/python -m playwright install --with-deps chromium
 
-      - name: Run real mouse interaction regression
+      - name: Run real mouse interaction regressions
         id: real-plan-test
         shell: bash
         env:
@@ -40,13 +40,28 @@ jobs:
           PLAN_PASSWORD: ${{ secrets.DJANGO_ADMIN_PASSWORD }}
           PLAN_STUDENT_LABEL: نمونه تجربی دوازدهم
           PLAN_TEST_WEEK: 1499-02-01
+          PLAN_SCHOOL_TEST_WEEK: 1499-03-01
         run: |
           set +e
           export PLAN_USERNAME="${PLAN_USERNAME:-admin}"
+
           .plan-real-browser-venv/bin/python deploy/plan_real_interaction_e2e.py \
             > plan-real-interaction-output.txt 2>&1
-          status=$?
+          core_status=$?
+
+          .plan-real-browser-venv/bin/python deploy/plan_school_drag_e2e.py \
+            > plan-school-drag-output.txt 2>&1
+          school_status=$?
+
+          echo '===== Core real interactions ====='
           cat plan-real-interaction-output.txt
+          echo '===== School-block drag interactions ====='
+          cat plan-school-drag-output.txt
+
+          status=0
+          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ]; then
+            status=1
+          fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
           exit "$status"
 
@@ -55,7 +70,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: plan-real-interaction-output
-          path: plan-real-interaction-output.txt
+          path: |
+            plan-real-interaction-output.txt
+            plan-school-drag-output.txt
           retention-days: 3
 
       - name: Publish real interaction status
@@ -71,10 +88,10 @@ jobs:
           set -euo pipefail
           if [ "${TEST_STATUS:-1}" = "0" ]; then
             STATE='success'
-            DESCRIPTION='Real Plan drag, move, resize and compact controls passed.'
+            DESCRIPTION='Real Plan drag, resize, compact controls and school-block movement passed.'
           else
             STATE='failure'
-            DESCRIPTION='Real Plan mouse interaction regression failed.'
+            DESCRIPTION='Real Plan interaction or school-block drag regression failed.'
           fi
 
           jq -n \

--- a/deploy/plan_school_drag_e2e.py
+++ b/deploy/plan_school_drag_e2e.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import os
+import sys
+from urllib.parse import urljoin
+
+from playwright.sync_api import Locator, Page, sync_playwright
+
+
+BASE_URL = os.environ.get(
+    "PLAN_BASE_URL", "https://panel.kimiagarkhoone.com"
+).rstrip("/") + "/"
+USERNAME = os.environ.get("PLAN_USERNAME", "").strip()
+PASSWORD = os.environ.get("PLAN_PASSWORD", "")
+TEST_WEEK = os.environ.get("PLAN_SCHOOL_TEST_WEEK", "1499-03-01")
+STUDENT_LABEL = os.environ.get(
+    "PLAN_STUDENT_LABEL", "نمونه تجربی دوازدهم"
+)
+GRID_PIXELS = 8.75
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+    print(f"PASS: {message}")
+
+
+def relative_top(task: Locator, container: Locator) -> float:
+    task_box = task.bounding_box()
+    container_box = container.bounding_box()
+    if not task_box or not container_box:
+        raise AssertionError("Could not read task/container position")
+    return task_box["y"] - container_box["y"]
+
+
+def load_test_week(page: Page) -> None:
+    page.select_option("#student-select", label=STUDENT_LABEL)
+    page.evaluate(
+        """
+        value => {
+          window.jQuery('#weekSelector')
+            .val(value)
+            .trigger('input')
+            .trigger('change');
+        }
+        """,
+        TEST_WEEK,
+    )
+    page.click("#loadWeek")
+    page.wait_for_function(
+        "window.planRuntimeState && "
+        "window.planRuntimeState.loaded && "
+        "!window.planRuntimeState.loading",
+        timeout=30_000,
+    )
+    page.wait_for_function(
+        "document.querySelectorAll('.calendar .task-container.ui-droppable').length === 7",
+        timeout=15_000,
+    )
+    page.wait_for_function(
+        "document.querySelector('script[data-plan-drag-surface=true]')",
+        timeout=15_000,
+    )
+
+
+def drag_palette_to(
+    page: Page,
+    source: Locator,
+    target: Locator,
+    desired_top: float,
+) -> None:
+    source_box = source.bounding_box()
+    target_box = target.bounding_box()
+    if not source_box or not target_box:
+        raise AssertionError("Palette or target is not visible")
+
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2,
+        source_box["y"] + source_box["height"] / 2,
+    )
+    page.mouse.down()
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2 + 6,
+        source_box["y"] + source_box["height"] / 2 + 6,
+        steps=3,
+    )
+    page.mouse.move(
+        target_box["x"] + target_box["width"] / 2,
+        target_box["y"] + desired_top,
+        steps=28,
+    )
+    page.mouse.up()
+    page.wait_for_timeout(300)
+
+
+def drag_task_via_school(
+    page: Page,
+    task: Locator,
+    target: Locator,
+    desired_top: float,
+    *,
+    school_waypoint_top: float = 140,
+    grab_offset: float = 14,
+) -> None:
+    task_box = task.bounding_box()
+    target_box = target.bounding_box()
+    if not task_box or not target_box:
+        raise AssertionError("Task or target is not visible")
+
+    start_x = task_box["x"] + task_box["width"] / 2
+    start_y = task_box["y"] + grab_offset
+    target_x = target_box["x"] + target_box["width"] / 2
+
+    page.mouse.move(start_x, start_y)
+    page.mouse.down()
+    page.mouse.move(start_x + 6, start_y + 6, steps=3)
+    page.wait_for_function(
+        "document.body.classList.contains('plan-calendar-drag-active')",
+        timeout=5_000,
+    )
+
+    # Deliberately pass through the large school event before ending below it.
+    page.mouse.move(
+        start_x,
+        target_box["y"] + school_waypoint_top + grab_offset,
+        steps=16,
+    )
+    page.mouse.move(
+        target_x,
+        target_box["y"] + school_waypoint_top + grab_offset,
+        steps=20,
+    )
+    page.mouse.move(
+        target_x,
+        target_box["y"] + desired_top + grab_offset,
+        steps=20,
+    )
+    page.mouse.up()
+    page.wait_for_timeout(350)
+
+
+def main() -> int:
+    if not USERNAME or not PASSWORD:
+        print("PLAN_USERNAME and PLAN_PASSWORD are required.", file=sys.stderr)
+        return 2
+
+    page_errors: list[str] = []
+    dialogs: list[str] = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(
+            locale="fa-IR",
+            viewport={"width": 1700, "height": 1100},
+        )
+        page = context.new_page()
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+
+        def accept_dialog(dialog) -> None:
+            dialogs.append(dialog.message)
+            dialog.accept()
+
+        page.on("dialog", accept_dialog)
+        page.goto(
+            urljoin(BASE_URL, "login/"),
+            wait_until="domcontentloaded",
+            timeout=30_000,
+        )
+        page.fill("#username", USERNAME)
+        page.fill("#password", PASSWORD)
+        page.click('form button[type="submit"]')
+        page.wait_for_url("**/plan/", timeout=30_000)
+        page.wait_for_function("window.jQuery && window.jQuery.ui", timeout=20_000)
+        load_test_week(page)
+
+        school_count = page.evaluate(
+            """
+            () => Array.from(document.querySelectorAll('.calendar-task')).filter(task => {
+              const title = task.querySelector('.task-title');
+              return title && String(title.value || title.textContent || '').trim() === 'مدرسه';
+            }).length
+            """
+        )
+        require(school_count >= 5, "five default school blocks remain visible")
+        require(
+            not any("برنامه آینده" in message for message in dialogs),
+            "demo student is not blocked by a synthetic far-future report",
+        )
+
+        containers = page.locator(".calendar .task-container")
+        first = containers.nth(0)
+        second = containers.nth(1)
+        lesson_palette = page.locator(
+            ".subjects-box .plan-lesson-palette"
+        ).first
+
+        drag_palette_to(page, lesson_palette, first, 525)
+        study = first.locator(
+            '.calendar-task[data-box-type="مطالعه"]'
+        ).first
+        require(study.count() == 1, "study box is created below school hours")
+
+        drag_task_via_school(page, study, second, 560)
+        moved_study = second.locator(
+            '.calendar-task[data-box-type="مطالعه"]'
+        ).first
+        require(
+            moved_study.count() == 1,
+            "study box moves to another day while school blocks exist",
+        )
+        require(
+            abs(relative_top(moved_study, second) - 560) <= GRID_PIXELS + 2,
+            "school blocks do not corrupt the intended evening drop time",
+        )
+        require(
+            not page.locator("body").evaluate(
+                "body => body.classList.contains('plan-calendar-drag-active')"
+            ),
+            "drag surface mode is cleared after mouse release",
+        )
+
+        original_top = relative_top(moved_study, second)
+        drag_task_via_school(
+            page,
+            moved_study,
+            first,
+            105,
+            school_waypoint_top=150,
+        )
+        require(
+            second.locator('.calendar-task[data-box-type="مطالعه"]').count() == 1
+            and abs(relative_top(moved_study, second) - original_top)
+            <= GRID_PIXELS + 2,
+            "school time still rejects overlap and restores the previous position",
+        )
+
+        require(
+            not page_errors,
+            "school-block drag produces no uncaught JavaScript errors: "
+            + " | ".join(page_errors),
+        )
+        context.close()
+        browser.close()
+
+    print("School-block Plan drag regression completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plans/management/commands/cleanup_plan_demo_reports.py
+++ b/plans/management/commands/cleanup_plan_demo_reports.py
@@ -1,0 +1,51 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from plans.models import WeeklyReport
+
+
+DEMO_USERNAME_PREFIX = "demo_plan_student_"
+DEFAULT_HORIZON_DAYS = 3650
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete implausibly far-future weekly reports belonging only to Plan demo "
+        "students. This removes synthetic browser-test data without touching real students."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--database",
+            default="default",
+            help="Database alias to clean.",
+        )
+        parser.add_argument(
+            "--horizon-days",
+            type=int,
+            default=DEFAULT_HORIZON_DAYS,
+            help="Delete demo reports later than this many days from now.",
+        )
+
+    def handle(self, *args, **options):
+        using = options["database"]
+        horizon_days = max(365, int(options["horizon_days"]))
+        cutoff = timezone.now() + timedelta(days=horizon_days)
+
+        queryset = WeeklyReport.objects.using(using).filter(
+            student__profile__user__username__startswith=DEMO_USERNAME_PREFIX,
+            week_start__gt=cutoff,
+        )
+        report_count = queryset.count()
+        deleted_objects, _details = queryset.delete()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Plan demo report cleanup complete: "
+                f"{report_count} weekly report(s) removed "
+                f"({deleted_objects} total related object(s)); "
+                f"cutoff={cutoff.date().isoformat()}."
+            )
+        )

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260721-5"
+ASSET_VERSION = "20260722-1"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
 )
@@ -15,6 +15,7 @@ RUNTIME_PATHS = (
     ("plans/plan-secondary.js", "data-plan-secondary"),
     ("plans/plan-interactions.js", "data-plan-interactions"),
     ("plans/plan-manual-resize.js", "data-plan-manual-resize"),
+    ("plans/plan-drag-surface.js", "data-plan-drag-surface"),
 )
 
 

--- a/plans/static/plans/plan-drag-surface.js
+++ b/plans/static/plans/plan-drag-surface.js
@@ -1,0 +1,53 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$ || !$.ui) {
+    return;
+  }
+
+  const ACTIVE_BODY_CLASS = 'plan-calendar-drag-active';
+  const ACTIVE_SOURCE_CLASS = 'plan-active-drag-source';
+
+  function beginDrag(element) {
+    const $source = $(element);
+    $('body').addClass(ACTIVE_BODY_CLASS);
+    $source.addClass(ACTIVE_SOURCE_CLASS);
+  }
+
+  function endDrag(element) {
+    if (element) {
+      $(element).removeClass(ACTIVE_SOURCE_CLASS);
+    }
+    $('.' + ACTIVE_SOURCE_CLASS).removeClass(ACTIVE_SOURCE_CLASS);
+    $('body').removeClass(ACTIVE_BODY_CLASS);
+  }
+
+  function initialize() {
+    $(document)
+      .off('dragstart.planDragSurface', '.calendar-task, .task, .other-plan-task')
+      .on('dragstart.planDragSurface', '.calendar-task, .task, .other-plan-task', function () {
+        beginDrag(this);
+      })
+      .off('dragstop.planDragSurface', '.calendar-task, .task, .other-plan-task')
+      .on('dragstop.planDragSurface', '.calendar-task, .task, .other-plan-task', function () {
+        endDrag(this);
+      })
+      .off('mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface')
+      .on(
+        'mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface',
+        function () {
+          window.setTimeout(function () {
+            endDrag();
+          }, 0);
+        }
+      );
+
+    window.addEventListener('blur', function () {
+      endDrag();
+    });
+
+    window.dispatchEvent(new CustomEvent('plan:drag-surface-ready'));
+  }
+
+  $(initialize);
+})(window, document, window.jQuery);

--- a/plans/static/plans/plan-interactions.css
+++ b/plans/static/plans/plan-interactions.css
@@ -9,6 +9,19 @@
   opacity: 0.28;
 }
 
+body.plan-calendar-drag-active {
+  cursor: grabbing;
+  user-select: none;
+}
+
+body.plan-calendar-drag-active .calendar .calendar-task:not(.plan-dragging-source):not(.plan-active-drag-source) {
+  pointer-events: none !important;
+}
+
+body.plan-calendar-drag-active .calendar .task-container {
+  pointer-events: auto !important;
+}
+
 .plan-drag-ghost {
   opacity: 0.88 !important;
   pointer-events: none !important;

--- a/plans/test_plan_defaults.py
+++ b/plans/test_plan_defaults.py
@@ -1,10 +1,13 @@
+from datetime import timedelta
+
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.test import TestCase
+from django.utils import timezone
 
 from accounts.models import Student
 from plans.default_plan_data import ensure_advisor_for_user, seed_plan_defaults
-from plans.models import Box, BoxType, DefaultEvent
+from plans.models import Box, BoxType, DefaultEvent, WeeklyReport
 
 
 class PlanDefaultSeedTests(TestCase):
@@ -109,3 +112,33 @@ class PlanDefaultSeedTests(TestCase):
         events = events_response.json()
         self.assertEqual(len(events), 5)
         self.assertTrue(all(event["name"] == "مدرسه" for event in events))
+
+    def test_far_future_reports_are_cleaned_only_for_demo_students(self):
+        User = get_user_model()
+        admin = User.objects.create_superuser(
+            username="cleanup-admin",
+            email="cleanup@example.com",
+            password="test-password",
+        )
+        advisor = ensure_advisor_for_user(admin)
+        seed_plan_defaults(advisor=advisor)
+        demo_student = Student.objects.get(
+            profile__user__username="demo_plan_student_t"
+        )
+
+        now = timezone.now()
+        near_report = WeeklyReport.objects.create(
+            student=demo_student,
+            week_start=now + timedelta(days=30),
+            week_end=now + timedelta(days=36),
+        )
+        far_report = WeeklyReport.objects.create(
+            student=demo_student,
+            week_start=now + timedelta(days=4000),
+            week_end=now + timedelta(days=4006),
+        )
+
+        call_command("cleanup_plan_demo_reports", verbosity=0)
+
+        self.assertTrue(WeeklyReport.objects.filter(pk=near_report.pk).exists())
+        self.assertFalse(WeeklyReport.objects.filter(pk=far_report.pk).exists())

--- a/plans/test_plan_secondary.py
+++ b/plans/test_plan_secondary.py
@@ -26,15 +26,25 @@ class PlanSecondaryScriptTests(TestCase):
         secondary = b'/static/plans/plan-secondary.js?v='
         interactions = b'/static/plans/plan-interactions.js?v='
         manual_resize = b'/static/plans/plan-manual-resize.js?v='
+        drag_surface = b'/static/plans/plan-drag-surface.js?v='
 
-        for marker in (style, runtime, secondary, interactions, manual_resize):
+        for marker in (
+            style,
+            runtime,
+            secondary,
+            interactions,
+            manual_resize,
+            drag_surface,
+        ):
             self.assertEqual(content.count(marker), 1)
 
         self.assertLess(content.index(style), content.index(runtime))
         self.assertLess(content.index(runtime), content.index(secondary))
         self.assertLess(content.index(secondary), content.index(interactions))
         self.assertLess(content.index(interactions), content.index(manual_resize))
-        self.assertLess(content.index(manual_resize), content.rfind(b"</body>"))
+        self.assertLess(content.index(manual_resize), content.index(drag_surface))
+        self.assertLess(content.index(drag_surface), content.rfind(b"</body>"))
         self.assertIn(b'data-plan-interactions="true"', content)
         self.assertIn(b'data-plan-manual-resize="true"', content)
+        self.assertIn(b'data-plan-drag-surface="true"', content)
         self.assertIn(b'data-plan-interactions-style="true"', content)


### PR DESCRIPTION
## باگ ۱: خراب شدن Drag وقتی باکس‌های مدرسه وجود دارند
باکس‌های بزرگ مدرسه در زمان Drag همچنان hit-test و Pointer event دریافت می‌کردند. در نتیجه عبور موس از روی آن‌ها می‌توانست چرخه Droppable باکس دیگر را مختل کند.

### اصلاح
- Runtime جدید `plan-drag-surface.js` وضعیت Drag فعال را روی body مدیریت می‌کند.
- در زمان Drag، همه باکس‌های غیر از Source موقتاً `pointer-events: none` می‌گیرند.
- خود `task-container` همچنان Drop را دریافت می‌کند.
- محاسبه overlap تغییری نکرده است؛ بنابراین Drop داخل ساعت مدرسه هنوز رد می‌شود.
- کلاس Drag در mouseup/pointerup/cancel/blur پاک می‌شود تا UI در حالت گیرکرده نماند.

## باگ ۲: پیام برنامه آینده در تاریخ 2120-03-21
تست production با تاریخ جلالی ۱۴۹۹ ذخیره می‌کرد که معادل سال ۲۱۲۰ میلادی است و گزارش تستی روی دانش‌آموز نمونه باقی می‌ماند.

### اصلاح
- Management command جدید `cleanup_plan_demo_reports`
- حذف فقط WeeklyReportهای اکانت‌های `demo_plan_student_*` که بیش از ۱۰ سال آینده‌اند
- اجرای Cleanup قبل از تست برای حذف رکورد فعلی
- اجرای Cleanup با `if: always()` بعد از تست تا تست بعدی دوباره داده ۲۱۲۰ باقی نگذارد
- هیچ گزارش دانش‌آموز واقعی حذف نمی‌شود

## Regression واقعی
سناریوی Playwright جدید:
- صفحه با حداقل پنج باکس مدرسه باز می‌شود
- یک باکس مطالعه زیر ساعت مدرسه ساخته می‌شود
- Pointer عمداً از روی باکس بزرگ مدرسه عبور می‌کند
- باکس به روز دیگر و ساعت شب منتقل می‌شود
- سپس Drop داخل بازه مدرسه امتحان می‌شود و باید باکس به جای قبلی برگردد
- نبود پیام «برنامه آینده» و خطای JavaScript هم بررسی می‌شود