### PR TITLE
Start Plan drag guard on pointer down

### DIFF
--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260722-1"
+ASSET_VERSION = "20260722-2"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
 )

--- a/plans/static/plans/plan-drag-surface.js
+++ b/plans/static/plans/plan-drag-surface.js
@@ -7,6 +7,17 @@
 
   const ACTIVE_BODY_CLASS = 'plan-calendar-drag-active';
   const ACTIVE_SOURCE_CLASS = 'plan-active-drag-source';
+  const DRAGGABLE_SELECTOR = '.calendar-task, .task, .other-plan-task';
+  const CANCEL_SELECTOR = [
+    'button',
+    'input',
+    'textarea',
+    'select',
+    'option',
+    '.select2-container',
+    '.plan-resize-handle',
+    '.plan-study-compact'
+  ].join(', ');
 
   function beginDrag(element) {
     const $source = $(element);
@@ -22,19 +33,37 @@
     $('body').removeClass(ACTIVE_BODY_CLASS);
   }
 
+  function canBegin(event) {
+    const original = event.originalEvent || event;
+    if (original.button !== undefined && original.button !== 0) {
+      return false;
+    }
+    return !$(event.target).closest(CANCEL_SELECTOR).length;
+  }
+
   function initialize() {
     $(document)
-      .off('dragstart.planDragSurface', '.calendar-task, .task, .other-plan-task')
-      .on('dragstart.planDragSurface', '.calendar-task, .task, .other-plan-task', function () {
+      .off('pointerdown.planDragSurface mousedown.planDragSurface touchstart.planDragSurface', DRAGGABLE_SELECTOR)
+      .on(
+        'pointerdown.planDragSurface mousedown.planDragSurface touchstart.planDragSurface',
+        DRAGGABLE_SELECTOR,
+        function (event) {
+          if (canBegin(event)) {
+            beginDrag(this);
+          }
+        }
+      )
+      .off('dragstart.planDragSurface', DRAGGABLE_SELECTOR)
+      .on('dragstart.planDragSurface', DRAGGABLE_SELECTOR, function () {
         beginDrag(this);
       })
-      .off('dragstop.planDragSurface', '.calendar-task, .task, .other-plan-task')
-      .on('dragstop.planDragSurface', '.calendar-task, .task, .other-plan-task', function () {
+      .off('dragstop.planDragSurface', DRAGGABLE_SELECTOR)
+      .on('dragstop.planDragSurface', DRAGGABLE_SELECTOR, function () {
         endDrag(this);
       })
-      .off('mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface')
+      .off('mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface touchcancel.planDragSurface')
       .on(
-        'mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface',
+        'mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface touchcancel.planDragSurface',
         function () {
           window.setTimeout(function () {
             endDrag();


### PR DESCRIPTION
تست production نشان داد رویداد jQuery UI با نام `dragstart` روی document bubble نمی‌شود؛ بنابراین Drag Surface Guard فعال نمی‌شد.

این Hotfix:
- Guard را روی `pointerdown / mousedown / touchstart` مستقیم و delegated برای خود باکس‌ها فعال می‌کند.
- کنترل‌هایی که ذاتاً Drag را لغو می‌کنند مستثنی هستند: input، button، Select2، مداد و Resize handle.
- `dragstart` به‌عنوان fallback حفظ شده است.
- در mouseup/pointerup/cancel/blur حالت Guard پاک می‌شود.
- نسخه Asset تغییر کرده تا مرورگر JS قبلی را از Cache نگیرد.

تست واقعی قبلی دوباره اجرا می‌شود: Pointer از روی باکس مدرسه عبور می‌کند، Drop شب در روز دیگر باید موفق باشد و Drop داخل ساعت مدرسه باید به جای قبلی برگردد.