### PR TITLE
Wrap Plan draggable lifecycle for school-block movement

### DIFF
--- a/deploy/plan_school_drag_e2e.py
+++ b/deploy/plan_school_drag_e2e.py
@@ -100,15 +100,18 @@ def drag_task_via_school(
     desired_top: float,
     *,
     school_waypoint_top: float = 140,
-    grab_offset: float = 14,
 ) -> None:
     task_box = task.bounding_box()
+    title_box = task.locator(".task-title").first.bounding_box()
     target_box = target.bounding_box()
-    if not task_box or not target_box:
-        raise AssertionError("Task or target is not visible")
+    if not task_box or not title_box or not target_box:
+        raise AssertionError("Task title or target is not visible")
 
-    start_x = task_box["x"] + task_box["width"] / 2
-    start_y = task_box["y"] + grab_offset
+    # Study boxes contain Select2 controls that intentionally cancel dragging.
+    # Grab the title, which is the actual calendar drag surface for the box.
+    start_x = title_box["x"] + title_box["width"] / 2
+    start_y = title_box["y"] + title_box["height"] / 2
+    grab_offset = start_y - task_box["y"]
     target_x = target_box["x"] + target_box["width"] / 2
 
     page.mouse.move(start_x, start_y)

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260722-2"
+ASSET_VERSION = "20260722-3"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
 )

--- a/plans/static/plans/plan-drag-surface.js
+++ b/plans/static/plans/plan-drag-surface.js
@@ -41,6 +41,59 @@
     return !$(event.target).closest(CANCEL_SELECTOR).length;
   }
 
+  function draggableInstance($element) {
+    try {
+      return $element.draggable('instance') || null;
+    } catch (_error) {
+      return $element.data('ui-draggable') || $element.data('uiDraggable') || null;
+    }
+  }
+
+  function wrapDraggable($element) {
+    const instance = draggableInstance($element);
+    if (!instance || !instance.options) {
+      return;
+    }
+
+    const currentStart = instance.options.start;
+    if (currentStart && currentStart.planDragSurfaceWrapped) {
+      return;
+    }
+    const currentStop = instance.options.stop;
+
+    const wrappedStart = function (event, ui) {
+      beginDrag(this);
+      if (typeof currentStart === 'function') {
+        return currentStart.call(this, event, ui);
+      }
+      return undefined;
+    };
+    wrappedStart.planDragSurfaceWrapped = true;
+    wrappedStart.planDragSurfaceOriginal = currentStart;
+
+    const wrappedStop = function (event, ui) {
+      try {
+        if (typeof currentStop === 'function') {
+          return currentStop.call(this, event, ui);
+        }
+        return undefined;
+      } finally {
+        endDrag(this);
+      }
+    };
+    wrappedStop.planDragSurfaceWrapped = true;
+    wrappedStop.planDragSurfaceOriginal = currentStop;
+
+    instance.options.start = wrappedStart;
+    instance.options.stop = wrappedStop;
+  }
+
+  function synchronize() {
+    $(DRAGGABLE_SELECTOR).each(function () {
+      wrapDraggable($(this));
+    });
+  }
+
   function initialize() {
     $(document)
       .off('pointerdown.planDragSurface mousedown.planDragSurface touchstart.planDragSurface', DRAGGABLE_SELECTOR)
@@ -53,14 +106,6 @@
           }
         }
       )
-      .off('dragstart.planDragSurface', DRAGGABLE_SELECTOR)
-      .on('dragstart.planDragSurface', DRAGGABLE_SELECTOR, function () {
-        beginDrag(this);
-      })
-      .off('dragstop.planDragSurface', DRAGGABLE_SELECTOR)
-      .on('dragstop.planDragSurface', DRAGGABLE_SELECTOR, function () {
-        endDrag(this);
-      })
       .off('mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface touchcancel.planDragSurface')
       .on(
         'mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface touchcancel.planDragSurface',
@@ -71,10 +116,19 @@
         }
       );
 
+    const calendar = document.querySelector('.calendar');
+    if (calendar) {
+      new MutationObserver(function () {
+        window.requestAnimationFrame(synchronize);
+      }).observe(calendar, { childList: true, subtree: true });
+    }
+
     window.addEventListener('blur', function () {
       endDrag();
     });
 
+    synchronize();
+    window.setInterval(synchronize, 250);
     window.dispatchEvent(new CustomEvent('plan:drag-surface-ready'));
   }
 


### PR DESCRIPTION
دو مشکل تست قبلی هم‌زمان برطرف شد:

1. Guard اکنون مستقیماً `instance.options.start/stop` واقعی jQuery UI Draggable را Wrap می‌کند؛ بنابراین به bubbling رویدادهای سفارشی وابسته نیست.
2. تست باکس مطالعه را از `.task-title` می‌گیرد، نه از ناحیه Select2 که عمداً Drag را cancel می‌کند.

رفتار مورد انتظار:
- شروع Drag حتماً body را وارد حالت `plan-calendar-drag-active` می‌کند.
- باکس‌های مدرسه و سایر باکس‌های غیر Source هنگام حرکت Pointer را نمی‌دزدند.
- Droppable ستون روز فعال می‌ماند.
- بعد از Stop، Guard در `finally` پاک می‌شود.
- عبور Pointer از روی مدرسه و Drop در ساعت شب موفق است.
- Drop داخل بازه مدرسه همچنان به دلیل overlap رد و به محل قبلی برمی‌گردد.
- Asset version برای حذف Cache قبلی افزایش یافته است.