### PR TITLE
Capture Plan drag starts before jQuery UI

### DIFF
--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260722-3"
+ASSET_VERSION = "20260722-4"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
 )

--- a/plans/static/plans/plan-drag-surface.js
+++ b/plans/static/plans/plan-drag-surface.js
@@ -20,6 +20,9 @@
   ].join(', ');
 
   function beginDrag(element) {
+    if (!element) {
+      return;
+    }
     const $source = $(element);
     $('body').addClass(ACTIVE_BODY_CLASS);
     $source.addClass(ACTIVE_SOURCE_CLASS);
@@ -33,12 +36,60 @@
     $('body').removeClass(ACTIVE_BODY_CLASS);
   }
 
+  function eventElement(event) {
+    const target = event && event.target;
+    if (!target) {
+      return null;
+    }
+    if (target.nodeType === 1) {
+      return target;
+    }
+    return target.parentElement || null;
+  }
+
+  function sourceForEvent(event) {
+    const target = eventElement(event);
+    if (!target) {
+      return null;
+    }
+    if (target.closest(CANCEL_SELECTOR)) {
+      return null;
+    }
+    return target.closest(DRAGGABLE_SELECTOR);
+  }
+
   function canBegin(event) {
-    const original = event.originalEvent || event;
-    if (original.button !== undefined && original.button !== 0) {
+    if (event.button !== undefined && event.button !== 0) {
       return false;
     }
-    return !$(event.target).closest(CANCEL_SELECTOR).length;
+    return Boolean(sourceForEvent(event));
+  }
+
+  function captureStart(event) {
+    if (!canBegin(event)) {
+      return;
+    }
+    beginDrag(sourceForEvent(event));
+  }
+
+  function captureEnd() {
+    window.setTimeout(function () {
+      endDrag();
+    }, 0);
+  }
+
+  function bindCaptureListeners() {
+    if (window.__planDragSurfaceCaptureBound) {
+      return;
+    }
+    window.__planDragSurfaceCaptureBound = true;
+
+    ['pointerdown', 'mousedown', 'touchstart'].forEach(function (eventName) {
+      document.addEventListener(eventName, captureStart, true);
+    });
+    ['pointerup', 'mouseup', 'pointercancel', 'touchend', 'touchcancel'].forEach(function (eventName) {
+      document.addEventListener(eventName, captureEnd, true);
+    });
   }
 
   function draggableInstance($element) {
@@ -95,26 +146,7 @@
   }
 
   function initialize() {
-    $(document)
-      .off('pointerdown.planDragSurface mousedown.planDragSurface touchstart.planDragSurface', DRAGGABLE_SELECTOR)
-      .on(
-        'pointerdown.planDragSurface mousedown.planDragSurface touchstart.planDragSurface',
-        DRAGGABLE_SELECTOR,
-        function (event) {
-          if (canBegin(event)) {
-            beginDrag(this);
-          }
-        }
-      )
-      .off('mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface touchcancel.planDragSurface')
-      .on(
-        'mouseup.planDragSurface pointerup.planDragSurface pointercancel.planDragSurface touchend.planDragSurface touchcancel.planDragSurface',
-        function () {
-          window.setTimeout(function () {
-            endDrag();
-          }, 0);
-        }
-      );
+    bindCaptureListeners();
 
     const calendar = document.querySelector('.calendar');
     if (calendar) {


### PR DESCRIPTION
تست Production نشان داد حتی Handlerهای delegated و wrapper lifecycle برای تشخیص شروع حرکت در این DOM کافی نیستند. این تغییر Guard را با Native Event Capture فعال می‌کند:

- `pointerdown / mousedown / touchstart` در capture phase
- اجرا قبل از jQuery UI و قبل از هر stopPropagation
- شناسایی نزدیک‌ترین `.calendar-task`, `.task` یا `.other-plan-task`
- مستثنی‌کردن input، button، Select2، مداد و Resize handle
- پاک‌سازی با capture listenerهای pointerup/mouseup/cancel/touchend و window blur
- wrapper واقعی draggable start/stop به‌عنوان لایه دوم حفظ شده است
- Cache bust برای دریافت قطعی نسخه جدید

سناریوی واقعی بدون تغییر اجرا می‌شود: پنج مدرسه حاضرند، Pointer از روی مدرسه رد می‌شود، Drop شب باید موفق و Drop داخل مدرسه باید رد شود.