### PR TITLE
Unify Plan time grid and restore student lesson rules

### DIFF
--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -9,6 +9,7 @@ on:
       - 'deploy/plan_e2e_runner.py'
       - 'deploy/plan_real_interaction_e2e.py'
       - 'deploy/plan_school_drag_e2e.py'
+      - 'deploy/plan_time_grid_e2e.py'
       - 'config/test_settings.py'
       - '.github/workflows/deploy.yml'
       - '.github/workflows/validate-plan.yml'
@@ -31,15 +32,19 @@ jobs:
         run: |
           node --check plans/static/plans/plan-runtime.js
           node --check plans/static/plans/plan-secondary.js
+          node --check plans/static/plans/plan-time-grid.js
           node --check plans/static/plans/plan-interactions.js
           node --check plans/static/plans/plan-manual-resize.js
           node --check plans/static/plans/plan-drag-surface.js
+          node --check plans/static/plans/plan-lesson-toolbar.js
           python3 -m py_compile \
             deploy/plan_e2e.py \
             deploy/plan_e2e_runner.py \
             deploy/plan_real_interaction_e2e.py \
             deploy/plan_school_drag_e2e.py \
+            deploy/plan_time_grid_e2e.py \
             plans/management/commands/cleanup_plan_demo_reports.py \
+            plans/lesson_catalog.py \
             plans/plan_page.py \
             plans/weekly_plans.py \
             plans/weekly_plans_v2.py
@@ -64,6 +69,7 @@ jobs:
             plans.test_plan_runtime \
             plans.test_plan_secondary \
             plans.test_plan_defaults \
+            plans.test_lesson_catalog \
             --verbosity 1 > plan-test-output.txt 2>&1
           status=$?
           cat plan-test-output.txt

--- a/.github/workflows/verify-plan-interactions.yml
+++ b/.github/workflows/verify-plan-interactions.yml
@@ -15,7 +15,7 @@ jobs:
   verify-real-interactions:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     steps:
       - name: Checkout deployed commit
@@ -41,6 +41,8 @@ jobs:
           PLAN_STUDENT_LABEL: نمونه تجربی دوازدهم
           PLAN_TEST_WEEK: 1499-02-01
           PLAN_SCHOOL_TEST_WEEK: 1499-03-01
+          PLAN_GRID_STUDENT_LABEL: نمونه ریاضی یازدهم
+          PLAN_GRID_TEST_WEEK: 1405-09-01
         run: |
           set +e
           export PLAN_USERNAME="${PLAN_USERNAME:-admin}"
@@ -53,13 +55,19 @@ jobs:
             > plan-school-drag-output.txt 2>&1
           school_status=$?
 
+          .plan-real-browser-venv/bin/python deploy/plan_time_grid_e2e.py \
+            > plan-time-grid-output.txt 2>&1
+          grid_status=$?
+
           echo '===== Core real interactions ====='
           cat plan-real-interaction-output.txt
           echo '===== School-block drag interactions ====='
           cat plan-school-drag-output.txt
+          echo '===== Time grid and lesson toolbar ====='
+          cat plan-time-grid-output.txt
 
           status=0
-          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ]; then
+          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ]; then
             status=1
           fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
@@ -73,6 +81,7 @@ jobs:
           path: |
             plan-real-interaction-output.txt
             plan-school-drag-output.txt
+            plan-time-grid-output.txt
           retention-days: 3
 
       - name: Publish real interaction status
@@ -88,10 +97,10 @@ jobs:
           set -euo pipefail
           if [ "${TEST_STATUS:-1}" = "0" ]; then
             STATE='success'
-            DESCRIPTION='Real Plan drag, resize, compact controls and school-block movement passed.'
+            DESCRIPTION='Plan drag, resize, school blocks, time grid and lesson rules passed.'
           else
             STATE='failure'
-            DESCRIPTION='Real Plan interaction or school-block drag regression failed.'
+            DESCRIPTION='Plan interaction, time-grid or lesson-toolbar regression failed.'
           fi
 
           jq -n \

--- a/deploy/plan_time_grid_e2e.py
+++ b/deploy/plan_time_grid_e2e.py
@@ -150,13 +150,21 @@ def main() -> int:
             "timeline hour marks are exactly 35 pixels apart",
         )
 
-        school_tasks = page.locator(".calendar .calendar-task").filter(
-            has=page.locator('.task-title[value="مدرسه"], .task-title:text-is("مدرسه")')
+        page.evaluate(
+            """
+            () => {
+              document.querySelectorAll('.calendar .calendar-task').forEach(task => {
+                task.classList.remove('plan-e2e-school-task');
+                const title = task.querySelector('.task-title');
+                const text = title ? String(title.value || title.textContent || '').trim() : '';
+                if (text === 'مدرسه') {
+                  task.classList.add('plan-e2e-school-task');
+                }
+              });
+            }
+            """
         )
-        if school_tasks.count() == 0:
-            school_tasks = page.locator(".calendar .calendar-task").filter(
-                has_text="مدرسه"
-            )
+        school_tasks = page.locator(".calendar .calendar-task.plan-e2e-school-task")
         require(school_tasks.count() >= 5, "default school blocks are loaded")
 
         school = school_tasks.first
@@ -171,30 +179,29 @@ def main() -> int:
             abs(school_box["height"] - 227.5) <= 2.0,
             "07:30–14:00 school duration uses the same time scale",
         )
+        school_label = school.locator(".time-label").inner_text()
         require(
-            "07:30" in school.locator(".time-label").inner_text()
-            and "14:00" in school.locator(".time-label").inner_text(),
+            "07:30" in school_label and "14:00" in school_label,
             "school time label matches its visual position and height",
         )
 
         toolbar = page.evaluate(
             """
-            () => ({
-              studentGrade: window.planLessonToolbarState.studentGrade,
-              majorCode: window.planLessonToolbarState.majorCode,
-              allowedIds: window.planLessonToolbarState.allowedGradeIds,
-              options: window.planLessonToolbarState.gradeOptions,
-              visibleGrades: Array.from(document.querySelectorAll(
-                '#specialized-task-list .task:visible, #general-task-list .task:visible'
-              )).map(item => String(item.dataset.grade || '')),
-              allGrades: Array.from(document.querySelectorAll(
+            () => {
+              const cards = Array.from(document.querySelectorAll(
                 '#specialized-task-list .task, #general-task-list .task'
-              )).map(item => String(item.dataset.grade || '')),
-              visibleText: Array.from(document.querySelectorAll(
-                '#specialized-task-list .task, #general-task-list .task'
-              )).filter(item => getComputedStyle(item).display !== 'none')
-                .map(item => item.textContent.trim())
-            })
+              ));
+              const visible = cards.filter(item => getComputedStyle(item).display !== 'none');
+              return {
+                studentGrade: window.planLessonToolbarState.studentGrade,
+                majorCode: window.planLessonToolbarState.majorCode,
+                allowedIds: window.planLessonToolbarState.allowedGradeIds,
+                options: window.planLessonToolbarState.gradeOptions,
+                visibleGrades: visible.map(item => String(item.dataset.grade || '')),
+                allGrades: cards.map(item => String(item.dataset.grade || '')),
+                visibleText: visible.map(item => item.textContent.trim())
+              };
+            }
             """
         )
         allowed_ids = {str(value) for value in toolbar["allowedIds"]}
@@ -230,10 +237,7 @@ def main() -> int:
         free_container = None
         for index in range(containers.count()):
             candidate = containers.nth(index)
-            school_count = candidate.locator(".calendar-task").filter(
-                has_text="مدرسه"
-            ).count()
-            if school_count == 0:
+            if candidate.locator(".plan-e2e-school-task").count() == 0:
                 free_container = candidate
                 break
         require(free_container is not None, "a non-school day is available for drop testing")

--- a/deploy/plan_time_grid_e2e.py
+++ b/deploy/plan_time_grid_e2e.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import os
+import sys
+from urllib.parse import urljoin
+
+from playwright.sync_api import Locator, Page, sync_playwright
+
+
+BASE_URL = os.environ.get(
+    "PLAN_BASE_URL", "https://panel.kimiagarkhoone.com"
+).rstrip("/") + "/"
+USERNAME = os.environ.get("PLAN_USERNAME", "").strip()
+PASSWORD = os.environ.get("PLAN_PASSWORD", "")
+TEST_WEEK = os.environ.get("PLAN_GRID_TEST_WEEK", "1405-09-01")
+STUDENT_LABEL = os.environ.get(
+    "PLAN_GRID_STUDENT_LABEL", "نمونه ریاضی یازدهم"
+)
+HOUR_HEIGHT = 35.0
+QUARTER_HEIGHT = 8.75
+GRID_HEIGHT = 630.0
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+    print(f"PASS: {message}")
+
+
+def relative_top(task: Locator, container: Locator) -> float:
+    task_box = task.bounding_box()
+    container_box = container.bounding_box()
+    if not task_box or not container_box:
+        raise AssertionError("Could not read task/container geometry")
+    return task_box["y"] - container_box["y"]
+
+
+def drag_palette_to(
+    page: Page,
+    source: Locator,
+    target: Locator,
+    desired_top: float,
+) -> None:
+    source.scroll_into_view_if_needed()
+    source_box = source.bounding_box()
+    target_box = target.bounding_box()
+    if not source_box or not target_box:
+        raise AssertionError("Palette or target is not visible")
+
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2,
+        source_box["y"] + source_box["height"] / 2,
+    )
+    page.mouse.down()
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2 + 6,
+        source_box["y"] + source_box["height"] / 2 + 6,
+        steps=3,
+    )
+    page.mouse.move(
+        target_box["x"] + target_box["width"] / 2,
+        target_box["y"] + desired_top,
+        steps=28,
+    )
+    page.mouse.up()
+    page.wait_for_timeout(350)
+
+
+def load_week(page: Page) -> None:
+    page.select_option("#student-select", label=STUDENT_LABEL)
+    page.evaluate(
+        """
+        value => {
+          window.jQuery('#weekSelector')
+            .val(value)
+            .trigger('input')
+            .trigger('change');
+        }
+        """,
+        TEST_WEEK,
+    )
+    page.click("#loadWeek")
+    page.wait_for_function(
+        "window.planRuntimeState && window.planRuntimeState.loaded && "
+        "!window.planRuntimeState.loading",
+        timeout=30_000,
+    )
+    page.wait_for_function(
+        "window.planTimeGrid && "
+        "document.body.dataset.planTimeGridVersion && "
+        "document.querySelectorAll('.calendar .plan-day-header').length === 7",
+        timeout=15_000,
+    )
+    page.wait_for_function(
+        "window.planLessonToolbarState && "
+        "String(window.planLessonToolbarState.studentGrade) === 'یازدهم' && "
+        "document.body.dataset.planLessonToolbarReady === 'true'",
+        timeout=15_000,
+    )
+    page.evaluate("window.planTimeGrid.synchronize()")
+    page.wait_for_timeout(150)
+
+
+def main() -> int:
+    if not USERNAME or not PASSWORD:
+        print("PLAN_USERNAME and PLAN_PASSWORD are required.", file=sys.stderr)
+        return 2
+
+    page_errors: list[str] = []
+    dialogs: list[str] = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(
+            locale="fa-IR",
+            viewport={"width": 1800, "height": 1050},
+        )
+        page = context.new_page()
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+
+        def accept_dialog(dialog) -> None:
+            dialogs.append(dialog.message)
+            dialog.accept()
+
+        page.on("dialog", accept_dialog)
+        page.goto(
+            urljoin(BASE_URL, "login/"),
+            wait_until="domcontentloaded",
+            timeout=30_000,
+        )
+        page.fill("#username", USERNAME)
+        page.fill("#password", PASSWORD)
+        page.click('form button[type="submit"]')
+        page.wait_for_url("**/plan/", timeout=30_000)
+        page.wait_for_function("window.jQuery && window.jQuery.ui", timeout=20_000)
+        load_week(page)
+
+        snapshot = page.evaluate("window.planTimeGrid.geometrySnapshot()")
+        require(snapshot is not None, "time grid exposes a geometry snapshot")
+        require(
+            abs(snapshot["gridHeight"] - GRID_HEIGHT) <= 1.5,
+            "day grid has the authoritative 18-hour height",
+        )
+        require(
+            abs(snapshot["sixCenter"] - snapshot["gridTop"]) <= 1.5,
+            "06:00 axis mark and day-grid origin are identical",
+        )
+        require(
+            abs(snapshot["hourDistance"] - HOUR_HEIGHT) <= 1.0,
+            "timeline hour marks are exactly 35 pixels apart",
+        )
+
+        school_tasks = page.locator(".calendar .calendar-task").filter(
+            has=page.locator('.task-title[value="مدرسه"], .task-title:text-is("مدرسه")')
+        )
+        if school_tasks.count() == 0:
+            school_tasks = page.locator(".calendar .calendar-task").filter(
+                has_text="مدرسه"
+            )
+        require(school_tasks.count() >= 5, "default school blocks are loaded")
+
+        school = school_tasks.first
+        school_container = school.locator("xpath=parent::*")
+        school_box = school.bounding_box()
+        require(school_box is not None, "school block geometry is readable")
+        require(
+            abs(relative_top(school, school_container) - 52.5) <= 2.0,
+            "07:30 school start aligns halfway between 07:00 and 08:00",
+        )
+        require(
+            abs(school_box["height"] - 227.5) <= 2.0,
+            "07:30–14:00 school duration uses the same time scale",
+        )
+        require(
+            "07:30" in school.locator(".time-label").inner_text()
+            and "14:00" in school.locator(".time-label").inner_text(),
+            "school time label matches its visual position and height",
+        )
+
+        toolbar = page.evaluate(
+            """
+            () => ({
+              studentGrade: window.planLessonToolbarState.studentGrade,
+              majorCode: window.planLessonToolbarState.majorCode,
+              allowedIds: window.planLessonToolbarState.allowedGradeIds,
+              options: window.planLessonToolbarState.gradeOptions,
+              visibleGrades: Array.from(document.querySelectorAll(
+                '#specialized-task-list .task:visible, #general-task-list .task:visible'
+              )).map(item => String(item.dataset.grade || '')),
+              allGrades: Array.from(document.querySelectorAll(
+                '#specialized-task-list .task, #general-task-list .task'
+              )).map(item => String(item.dataset.grade || '')),
+              visibleText: Array.from(document.querySelectorAll(
+                '#specialized-task-list .task, #general-task-list .task'
+              )).filter(item => getComputedStyle(item).display !== 'none')
+                .map(item => item.textContent.trim())
+            })
+            """
+        )
+        allowed_ids = {str(value) for value in toolbar["allowedIds"]}
+        allowed_names = {
+            option["name"]
+            for option in toolbar["options"]
+            if str(option["id"]) in allowed_ids
+        }
+        require(toolbar["studentGrade"] == "یازدهم", "selected student grade is یازدهم")
+        require(toolbar["majorCode"] == "R", "selected student major is ریاضی")
+        require(
+            allowed_names == {"دهم", "یازدهم"},
+            "eleventh-grade toolbar enables only tenth and eleventh grades",
+        )
+        require(
+            set(toolbar["allGrades"]).issubset(allowed_ids),
+            "future-grade lessons are absent from the toolbar data",
+        )
+        require(
+            set(toolbar["visibleGrades"]).issubset(allowed_ids),
+            "visible lesson cards obey enabled grade filters",
+        )
+        require(
+            not any("دوازدهم" in text for text in toolbar["visibleText"]),
+            "twelfth-grade lessons are not shown to an eleventh-grade student",
+        )
+        require(
+            not any("زیست" in text for text in toolbar["visibleText"]),
+            "math student toolbar excludes experimental-major lessons",
+        )
+
+        containers = page.locator(".calendar .task-container")
+        free_container = None
+        for index in range(containers.count()):
+            candidate = containers.nth(index)
+            school_count = candidate.locator(".calendar-task").filter(
+                has_text="مدرسه"
+            ).count()
+            if school_count == 0:
+                free_container = candidate
+                break
+        require(free_container is not None, "a non-school day is available for drop testing")
+
+        lesson_palette = page.locator(
+            ".subjects-box .plan-lesson-palette:visible"
+        ).first
+        require(lesson_palette.count() == 1, "an allowed lesson is visible in the toolbar")
+        drag_palette_to(page, lesson_palette, free_container, 210.0)
+
+        study = free_container.locator(
+            '.calendar-task[data-box-type="مطالعه"]'
+        ).first
+        require(study.count() == 1, "lesson can be dropped at the 12:00 row")
+        require(
+            abs(relative_top(study, free_container) - 210.0) <= QUARTER_HEIGHT + 1.0,
+            "study box visual top matches the 12:00 timeline position",
+        )
+        label = study.locator(".time-label").inner_text().strip()
+        require(
+            "12:00" in label and "13:30" in label,
+            "study time label is synchronized with its grid position",
+        )
+
+        require(
+            not any("برنامه آینده" in message for message in dialogs),
+            "grid test week is not blocked by a future-report dialog",
+        )
+        require(
+            not page_errors,
+            "time-grid and lesson-toolbar flow has no uncaught JavaScript errors: "
+            + " | ".join(page_errors),
+        )
+
+        context.close()
+        browser.close()
+
+    print("Plan time-grid and lesson-toolbar regression completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plans/lesson_catalog.py
+++ b/plans/lesson_catalog.py
@@ -4,7 +4,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import render
 
-from accounts.models import Advisor, Profile, Student
+from accounts.models import Advisor, Grade, Profile, Student
 from plans.default_plan_data import DEFAULT_BOXES
 from plans.models import Box, DefaultEvent, Lesson, WeeklyReportDetail
 
@@ -42,11 +42,48 @@ GENERAL_SUBJECTS = [
     "جغرافیا",
     "زمین",
 ]
+GRADE_SEQUENCE = ("دهم", "یازدهم", "دوازدهم")
 GRADE_ORDER = {
     "دوازدهم": 0,
     "یازدهم": 1,
     "دهم": 2,
 }
+
+
+def _normalized_name(value: object) -> str:
+    return (
+        str(value or "")
+        .strip()
+        .replace("\u200c", "")
+        .replace("\u200e", "")
+        .replace("\u200f", "")
+        .replace(" ", "")
+        .replace("ي", "ی")
+        .replace("ى", "ی")
+        .replace("ك", "ک")
+    )
+
+
+GRADE_BY_KEY = {_normalized_name(name): name for name in GRADE_SEQUENCE}
+
+
+def canonical_grade_name(value: object) -> str | None:
+    return GRADE_BY_KEY.get(_normalized_name(value))
+
+
+def allowed_grade_names(student: Student) -> set[str]:
+    """Return the student's current grade and all completed lower grades.
+
+    A tenth-grade student sees only tenth-grade lessons. An eleventh-grade
+    student sees tenth and eleventh grade. A twelfth-grade student sees all
+    three grades. Lessons from a future grade are never returned by the API.
+    """
+
+    current = canonical_grade_name(student.grade.name)
+    if current is None:
+        return {student.grade.name}
+    current_index = GRADE_SEQUENCE.index(current)
+    return set(GRADE_SEQUENCE[: current_index + 1])
 
 
 def _track_codes(lesson: Lesson) -> set[str]:
@@ -68,7 +105,7 @@ def _subject_order(subjects: list[str], lesson: Lesson) -> tuple[int, int, str, 
         subject_index = 999
     return (
         subject_index,
-        GRADE_ORDER.get(lesson.grade.name, 999),
+        GRADE_ORDER.get(canonical_grade_name(lesson.grade.name) or lesson.grade.name, 999),
         lesson.name,
         lesson.pk,
     )
@@ -95,6 +132,7 @@ def sort_lessons_for_student(student: Student) -> dict[str, list[Lesson]]:
     if not major_code:
         return {"specialized_lessons": [], "general_lessons": []}
 
+    allowed_grades = allowed_grade_names(student)
     lessons = (
         Lesson.objects.select_related("grade", "lesson_type")
         .prefetch_related("chapter_set")
@@ -104,6 +142,9 @@ def sort_lessons_for_student(student: Student) -> dict[str, list[Lesson]]:
     general_lessons: list[Lesson] = []
 
     for lesson in lessons:
+        lesson_grade = canonical_grade_name(lesson.grade.name) or lesson.grade.name
+        if lesson_grade not in allowed_grades:
+            continue
         if major_code not in _track_codes(lesson):
             continue
         if lesson.lesson_type.name == "اختصاصی":
@@ -132,6 +173,39 @@ def _serialize_lessons(lessons: list[Lesson]) -> list[dict[str, object]]:
         }
         for lesson in lessons
     ]
+
+
+def _grade_filter_payload(student: Student) -> dict[str, object]:
+    allowed_names = allowed_grade_names(student)
+    grade_objects = list(Grade.objects.all())
+    grade_by_name = {
+        canonical_grade_name(grade.name) or grade.name: grade for grade in grade_objects
+    }
+    grade_options = []
+    allowed_grade_ids = []
+    for grade_name in GRADE_SEQUENCE:
+        grade = grade_by_name.get(grade_name)
+        if grade is None:
+            continue
+        allowed = grade_name in allowed_names
+        grade_options.append(
+            {
+                "id": grade.pk,
+                "name": grade_name,
+                "allowed": allowed,
+                "current": grade.pk == student.grade_id,
+            }
+        )
+        if allowed:
+            allowed_grade_ids.append(grade.pk)
+
+    return {
+        "student_id": student.pk,
+        "student_grade_id": student.grade_id,
+        "student_grade": canonical_grade_name(student.grade.name) or student.grade.name,
+        "allowed_grade_ids": allowed_grade_ids,
+        "grade_options": grade_options,
+    }
 
 
 @login_required
@@ -164,10 +238,6 @@ def plan_view(request):
             request.user.get_full_name().strip() or request.user.get_username()
         )
 
-    # Important: return the template unmodified.  plan.html contains literal
-    # </body> and </script> strings inside JavaScript-generated report HTML.
-    # Post-processing response.content can inject markup inside those scripts
-    # and stop every calendar handler from being parsed by the browser.
     return render(
         request,
         "plans/plan.html",
@@ -207,6 +277,7 @@ def get_lessons_for_student(request):
                 lessons["specialized_lessons"]
             ),
             "general_lessons": _serialize_lessons(lessons["general_lessons"]),
+            **_grade_filter_payload(student),
         }
     )
 
@@ -282,7 +353,6 @@ def get_default_events(request):
             safe=False,
         )
 
-    # Backward-compatible fallback for events saved by the old implementation.
     legacy_details = (
         WeeklyReportDetail.objects.select_related("report", "box")
         .filter(

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,16 +6,19 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260722-4"
+ASSET_VERSION = "20260722-5"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
+    ("plans/plan-time-grid.css", "data-plan-time-grid-style"),
 )
 RUNTIME_PATHS = (
     ("plans/plan-runtime.js", "data-plan-runtime"),
     ("plans/plan-secondary.js", "data-plan-secondary"),
+    ("plans/plan-time-grid.js", "data-plan-time-grid"),
     ("plans/plan-interactions.js", "data-plan-interactions"),
     ("plans/plan-manual-resize.js", "data-plan-manual-resize"),
     ("plans/plan-drag-surface.js", "data-plan-drag-surface"),
+    ("plans/plan-lesson-toolbar.js", "data-plan-lesson-toolbar"),
 )
 
 

--- a/plans/static/plans/plan-lesson-toolbar.js
+++ b/plans/static/plans/plan-lesson-toolbar.js
@@ -1,0 +1,137 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$) {
+    return;
+  }
+
+  const ENDPOINT = '/get-lessons-for-student/';
+  let requestSerial = 0;
+
+  const state = {
+    studentId: null,
+    studentGradeId: null,
+    studentGrade: '',
+    majorCode: '',
+    allowedGradeIds: [],
+    gradeOptions: []
+  };
+
+  function normalizedUrl(value) {
+    try {
+      return new URL(value, window.location.origin).pathname;
+    } catch (_error) {
+      return String(value || '').split('?')[0];
+    }
+  }
+
+  function buildGradeFilters(response) {
+    const options = Array.isArray(response.grade_options) ? response.grade_options : [];
+    const allowed = new Set((response.allowed_grade_ids || []).map(String));
+    const studentGradeId = String(response.student_grade_id || '');
+    const $container = $('.subjects-box .grade-filters').first();
+    if (!$container.length || !options.length) {
+      return;
+    }
+
+    $container.empty();
+    options.forEach(function (option) {
+      const id = String(option.id);
+      const isAllowed = allowed.has(id);
+      const isCurrent = id === studentGradeId;
+      const $label = $('<label class="me-2"></label>')
+        .toggleClass('plan-grade-disabled', !isAllowed)
+        .toggleClass('plan-grade-current', isCurrent)
+        .attr('data-grade-name', option.name);
+      const $checkbox = $('<input type="checkbox" class="grade-filter">')
+        .val(id)
+        .prop('checked', isAllowed)
+        .prop('disabled', !isAllowed)
+        .attr('data-grade-name', option.name)
+        .attr('aria-label', option.name);
+      $label.append($checkbox).append(document.createTextNode(' ' + option.name));
+      $container.append($label);
+    });
+  }
+
+  function applyGradeFilter() {
+    const activeGrades = new Set(
+      $('.grade-filter:checked:not(:disabled)').map(function () {
+        return String(this.value);
+      }).get()
+    );
+
+    $('#specialized-task-list .task, #general-task-list .task').each(function () {
+      const gradeId = String($(this).attr('data-grade') || '');
+      $(this).toggle(activeGrades.has(gradeId));
+    });
+  }
+
+  function applyResponse(response) {
+    if (!response || response.error) {
+      return;
+    }
+
+    state.studentId = String(response.student_id || $('#student-select').val() || '');
+    state.studentGradeId = response.student_grade_id || null;
+    state.studentGrade = response.student_grade || '';
+    state.majorCode = response.major_code || '';
+    state.allowedGradeIds = (response.allowed_grade_ids || []).map(String);
+    state.gradeOptions = response.grade_options || [];
+
+    buildGradeFilters(response);
+    applyGradeFilter();
+    document.body.setAttribute('data-plan-lesson-toolbar-ready', 'true');
+    window.dispatchEvent(new CustomEvent('plan:lesson-toolbar-updated', {
+      detail: Object.assign({}, state)
+    }));
+  }
+
+  function fetchRules(studentId) {
+    const id = String(studentId || '').trim();
+    if (!id) {
+      return;
+    }
+    const serial = ++requestSerial;
+    $.ajax({
+      url: ENDPOINT,
+      method: 'GET',
+      dataType: 'json',
+      data: { student_id: id }
+    }).done(function (response) {
+      if (serial === requestSerial) {
+        applyResponse(response);
+      }
+    }).fail(function (xhr) {
+      console.error('Could not load lesson toolbar rules.', xhr.responseJSON || xhr.statusText);
+    });
+  }
+
+  window.planLessonToolbarState = state;
+  window.planLessonToolbarApply = applyResponse;
+  window.planLessonToolbarFilter = applyGradeFilter;
+
+  $(document)
+    .off('change.planLessonToolbar', '.grade-filter')
+    .on('change.planLessonToolbar', '.grade-filter', applyGradeFilter)
+    .off('change.planLessonStudent', '#student-select')
+    .on('change.planLessonStudent', '#student-select', function () {
+      fetchRules(this.value);
+    });
+
+  $(document).ajaxSuccess(function (_event, xhr, settings) {
+    if (normalizedUrl(settings && settings.url) !== ENDPOINT) {
+      return;
+    }
+    const response = xhr.responseJSON;
+    if (response) {
+      window.setTimeout(function () {
+        applyResponse(response);
+      }, 0);
+    }
+  });
+
+  $(function () {
+    fetchRules($('#student-select').val());
+  });
+})(window, document, window.jQuery);

--- a/plans/static/plans/plan-time-grid.css
+++ b/plans/static/plans/plan-time-grid.css
@@ -21,7 +21,7 @@
   align-content: start !important;
   height: calc(var(--plan-day-header-height) + var(--plan-grid-height) + 12px) !important;
   min-height: calc(var(--plan-day-header-height) + var(--plan-grid-height) + 12px) !important;
-  padding: 5px !important;
+  padding: 0 5px 5px !important;
   overflow: hidden !important;
   box-sizing: border-box !important;
 }
@@ -142,10 +142,6 @@
 }
 
 @media (max-width: 1100px) {
-  :root {
-    --plan-day-header-height: 62px;
-  }
-
   .calendar .plan-day-options {
     gap: 4px !important;
     font-size: 10px !important;

--- a/plans/static/plans/plan-time-grid.css
+++ b/plans/static/plans/plan-time-grid.css
@@ -1,0 +1,153 @@
+:root {
+  --plan-hour-height: 35px;
+  --plan-quarter-height: 8.75px;
+  --plan-grid-hours: 18;
+  --plan-grid-height: 630px;
+  --plan-day-header-height: 58px;
+}
+
+.calendar-container {
+  align-items: flex-start !important;
+}
+
+.calendar {
+  align-items: flex-start !important;
+  overflow-y: visible !important;
+}
+
+.calendar .day-column {
+  display: grid !important;
+  grid-template-rows: var(--plan-day-header-height) var(--plan-grid-height) !important;
+  align-content: start !important;
+  height: calc(var(--plan-day-header-height) + var(--plan-grid-height) + 12px) !important;
+  min-height: calc(var(--plan-day-header-height) + var(--plan-grid-height) + 12px) !important;
+  padding: 5px !important;
+  overflow: hidden !important;
+  box-sizing: border-box !important;
+}
+
+.calendar .plan-day-header {
+  height: var(--plan-day-header-height) !important;
+  min-height: var(--plan-day-header-height) !important;
+  display: grid !important;
+  grid-template-rows: minmax(18px, auto) minmax(22px, auto) !important;
+  align-content: center !important;
+  gap: 2px !important;
+  margin: 0 !important;
+  padding: 1px 2px 3px !important;
+  box-sizing: border-box !important;
+}
+
+.calendar .plan-day-header > h4 {
+  margin: 0 !important;
+  padding: 0 !important;
+  min-height: 18px !important;
+  line-height: 18px !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+.calendar .plan-day-options {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  flex-wrap: nowrap !important;
+  gap: 8px !important;
+  min-height: 22px !important;
+  line-height: 20px !important;
+  white-space: nowrap !important;
+}
+
+.calendar .plan-day-options > label {
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 3px !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  line-height: 20px !important;
+}
+
+.calendar .task-container {
+  position: relative !important;
+  grid-row: 2 !important;
+  width: 100% !important;
+  height: var(--plan-grid-height) !important;
+  min-height: var(--plan-grid-height) !important;
+  max-height: var(--plan-grid-height) !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  box-sizing: border-box !important;
+  overflow: visible !important;
+  background-color: #fff !important;
+  background-image:
+    linear-gradient(to bottom, rgba(100, 116, 139, 0.42) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(203, 213, 225, 0.42) 1px, transparent 1px) !important;
+  background-size:
+    100% var(--plan-hour-height),
+    100% var(--plan-quarter-height) !important;
+  background-position: 0 0, 0 0 !important;
+  background-repeat: repeat-y, repeat-y !important;
+}
+
+.calendar-container > .timeline {
+  position: relative !important;
+  display: block !important;
+  flex: 0 0 46px !important;
+  width: 46px !important;
+  height: var(--plan-grid-height) !important;
+  min-height: var(--plan-grid-height) !important;
+  margin: var(--plan-day-header-height) 0 0 0 !important;
+  padding: 0 3px 0 0 !important;
+  border: 0 !important;
+  box-sizing: border-box !important;
+  overflow: visible !important;
+}
+
+.calendar-container > .timeline .time-slot {
+  position: absolute !important;
+  right: 0 !important;
+  width: 42px !important;
+  height: 0 !important;
+  min-height: 0 !important;
+  margin: 0 !important;
+  padding: 0 0 0 4px !important;
+  border: 0 !important;
+  line-height: 1 !important;
+  text-align: left !important;
+  white-space: nowrap !important;
+  transform: translateY(-50%) !important;
+  color: #64748b !important;
+  font-size: 12px !important;
+  font-variant-numeric: tabular-nums !important;
+  box-sizing: border-box !important;
+}
+
+.calendar-container > .timeline .time-slot::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  width: 5px;
+  border-top: 1px solid rgba(100, 116, 139, 0.55);
+}
+
+.subjects-box .grade-filter:disabled + span,
+.subjects-box label.plan-grade-disabled {
+  opacity: 0.38;
+}
+
+.subjects-box .plan-grade-current {
+  font-weight: 700;
+}
+
+@media (max-width: 1100px) {
+  :root {
+    --plan-day-header-height: 62px;
+  }
+
+  .calendar .plan-day-options {
+    gap: 4px !important;
+    font-size: 10px !important;
+  }
+}

--- a/plans/static/plans/plan-time-grid.js
+++ b/plans/static/plans/plan-time-grid.js
@@ -1,0 +1,171 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$) {
+    return;
+  }
+
+  const START_HOUR = 6;
+  const END_HOUR = 24;
+  const HOURS = END_HOUR - START_HOUR;
+  const HOUR_HEIGHT = 35;
+  const QUARTER_HEIGHT = HOUR_HEIGHT / 4;
+  const GRID_HEIGHT = HOURS * HOUR_HEIGHT;
+  const HEADER_HEIGHT = 58;
+  const VERSION = '2026.07.22.1';
+
+  function pad(value) {
+    return String(value).padStart(2, '0');
+  }
+
+  function ensureDayHeaders() {
+    $('.calendar .day-column').each(function () {
+      const $column = $(this);
+      let $header = $column.children('.plan-day-header').first();
+      if (!$header.length) {
+        $header = $('<div class="plan-day-header"></div>');
+        const $heading = $column.children('h4').first();
+        const $labels = $column.children('label');
+        const $options = $('<div class="plan-day-options"></div>');
+        if ($heading.length) {
+          $header.append($heading);
+        }
+        $options.append($labels);
+        $header.append($options);
+        $column.prepend($header);
+      }
+    });
+  }
+
+  function layoutTimeline() {
+    const $timeline = $('.calendar-container > .timeline').first();
+    if (!$timeline.length) {
+      return;
+    }
+
+    let $slots = $timeline.children('.time-slot');
+    const expectedSlots = HOURS + 1;
+    if ($slots.length !== expectedSlots) {
+      $timeline.empty();
+      for (let index = 0; index < expectedSlots; index += 1) {
+        const hour = (START_HOUR + index) % 24;
+        $timeline.append(
+          $('<div class="time-slot"></div>').text(pad(hour) + ':00')
+        );
+      }
+      $slots = $timeline.children('.time-slot');
+    }
+
+    $slots.each(function (index) {
+      const hour = (START_HOUR + index) % 24;
+      $(this)
+        .text(pad(hour) + ':00')
+        .attr('data-plan-minute', index * 60)
+        .css('top', index * HOUR_HEIGHT + 'px');
+    });
+  }
+
+  function applyGeometryVariables() {
+    const root = document.documentElement;
+    root.style.setProperty('--plan-hour-height', HOUR_HEIGHT + 'px');
+    root.style.setProperty('--plan-quarter-height', QUARTER_HEIGHT + 'px');
+    root.style.setProperty('--plan-grid-hours', String(HOURS));
+    root.style.setProperty('--plan-grid-height', GRID_HEIGHT + 'px');
+    root.style.setProperty('--plan-day-header-height', HEADER_HEIGHT + 'px');
+  }
+
+  function normalizeTaskGeometry() {
+    $('.calendar .task-container').each(function () {
+      this.style.height = GRID_HEIGHT + 'px';
+      this.style.minHeight = GRID_HEIGHT + 'px';
+      this.style.maxHeight = GRID_HEIGHT + 'px';
+    });
+
+    $('.calendar .calendar-task').each(function () {
+      const $task = $(this);
+      const top = Number.parseFloat($task.css('top')) || 0;
+      const height = Number.parseFloat($task.css('height')) || QUARTER_HEIGHT;
+      const clampedTop = Math.max(0, Math.min(top, GRID_HEIGHT - Math.max(QUARTER_HEIGHT, height)));
+      if (Math.abs(clampedTop - top) > 0.1) {
+        $task.css('top', clampedTop + 'px');
+        if (typeof window.updateTimeLabel === 'function') {
+          window.updateTimeLabel($task);
+        }
+      }
+    });
+  }
+
+  function synchronize() {
+    applyGeometryVariables();
+    ensureDayHeaders();
+    layoutTimeline();
+    normalizeTaskGeometry();
+    document.body.setAttribute('data-plan-time-grid-version', VERSION);
+  }
+
+  function topForClock(hours, minutes) {
+    const total = Number(hours) * 60 + Number(minutes || 0) - START_HOUR * 60;
+    return Math.max(0, Math.min(total, HOURS * 60)) * HOUR_HEIGHT / 60;
+  }
+
+  function clockForTop(top) {
+    const total = START_HOUR * 60 + Math.round(Number(top || 0) * 60 / HOUR_HEIGHT);
+    return {
+      hour: Math.floor(total / 60) % 24,
+      minute: total % 60
+    };
+  }
+
+  function geometrySnapshot() {
+    const container = document.querySelector('.calendar .task-container');
+    const timeline = document.querySelector('.calendar-container > .timeline');
+    const six = timeline && timeline.querySelector('.time-slot[data-plan-minute="0"]');
+    const seven = timeline && timeline.querySelector('.time-slot[data-plan-minute="60"]');
+    if (!container || !timeline || !six || !seven) {
+      return null;
+    }
+    const containerRect = container.getBoundingClientRect();
+    const sixRect = six.getBoundingClientRect();
+    const sevenRect = seven.getBoundingClientRect();
+    return {
+      gridTop: containerRect.top,
+      gridHeight: containerRect.height,
+      sixCenter: sixRect.top + sixRect.height / 2,
+      sevenCenter: sevenRect.top + sevenRect.height / 2,
+      hourDistance: sevenRect.top - sixRect.top
+    };
+  }
+
+  window.planTimeGrid = {
+    version: VERSION,
+    startHour: START_HOUR,
+    endHour: END_HOUR,
+    hourHeight: HOUR_HEIGHT,
+    quarterHeight: QUARTER_HEIGHT,
+    gridHeight: GRID_HEIGHT,
+    topForClock: topForClock,
+    clockForTop: clockForTop,
+    synchronize: synchronize,
+    geometrySnapshot: geometrySnapshot
+  };
+
+  function initialize() {
+    synchronize();
+
+    const calendar = document.querySelector('.calendar');
+    if (calendar) {
+      new MutationObserver(function () {
+        window.requestAnimationFrame(synchronize);
+      }).observe(calendar, { childList: true, subtree: true });
+    }
+
+    window.addEventListener('resize', function () {
+      window.requestAnimationFrame(synchronize);
+    });
+    window.addEventListener('plan:interactions-ready', synchronize);
+    window.addEventListener('plan:drag-surface-ready', synchronize);
+    window.dispatchEvent(new CustomEvent('plan:time-grid-ready'));
+  }
+
+  $(initialize);
+})(window, document, window.jQuery);

--- a/plans/static/plans/plan-time-grid.js
+++ b/plans/static/plans/plan-time-grid.js
@@ -12,7 +12,8 @@
   const QUARTER_HEIGHT = HOUR_HEIGHT / 4;
   const GRID_HEIGHT = HOURS * HOUR_HEIGHT;
   const HEADER_HEIGHT = 58;
-  const VERSION = '2026.07.22.1';
+  const VERSION = '2026.07.22.2';
+  let synchronizeQueued = false;
 
   function pad(value) {
     return String(value).padStart(2, '0');
@@ -46,22 +47,29 @@
     let $slots = $timeline.children('.time-slot');
     const expectedSlots = HOURS + 1;
     if ($slots.length !== expectedSlots) {
-      $timeline.empty();
+      const fragment = document.createDocumentFragment();
       for (let index = 0; index < expectedSlots; index += 1) {
-        const hour = (START_HOUR + index) % 24;
-        $timeline.append(
-          $('<div class="time-slot"></div>').text(pad(hour) + ':00')
-        );
+        const slot = document.createElement('div');
+        slot.className = 'time-slot';
+        fragment.appendChild(slot);
       }
+      $timeline.empty().append(fragment);
       $slots = $timeline.children('.time-slot');
     }
 
     $slots.each(function (index) {
-      const hour = (START_HOUR + index) % 24;
-      $(this)
-        .text(pad(hour) + ':00')
-        .attr('data-plan-minute', index * 60)
-        .css('top', index * HOUR_HEIGHT + 'px');
+      const label = pad((START_HOUR + index) % 24) + ':00';
+      const minute = String(index * 60);
+      const top = index * HOUR_HEIGHT + 'px';
+      if (this.textContent !== label) {
+        this.textContent = label;
+      }
+      if (this.getAttribute('data-plan-minute') !== minute) {
+        this.setAttribute('data-plan-minute', minute);
+      }
+      if (this.style.top !== top) {
+        this.style.top = top;
+      }
     });
   }
 
@@ -76,16 +84,26 @@
 
   function normalizeTaskGeometry() {
     $('.calendar .task-container').each(function () {
-      this.style.height = GRID_HEIGHT + 'px';
-      this.style.minHeight = GRID_HEIGHT + 'px';
-      this.style.maxHeight = GRID_HEIGHT + 'px';
+      const height = GRID_HEIGHT + 'px';
+      if (this.style.height !== height) {
+        this.style.height = height;
+      }
+      if (this.style.minHeight !== height) {
+        this.style.minHeight = height;
+      }
+      if (this.style.maxHeight !== height) {
+        this.style.maxHeight = height;
+      }
     });
 
     $('.calendar .calendar-task').each(function () {
       const $task = $(this);
       const top = Number.parseFloat($task.css('top')) || 0;
       const height = Number.parseFloat($task.css('height')) || QUARTER_HEIGHT;
-      const clampedTop = Math.max(0, Math.min(top, GRID_HEIGHT - Math.max(QUARTER_HEIGHT, height)));
+      const clampedTop = Math.max(
+        0,
+        Math.min(top, GRID_HEIGHT - Math.max(QUARTER_HEIGHT, height))
+      );
       if (Math.abs(clampedTop - top) > 0.1) {
         $task.css('top', clampedTop + 'px');
         if (typeof window.updateTimeLabel === 'function') {
@@ -96,11 +114,22 @@
   }
 
   function synchronize() {
+    synchronizeQueued = false;
     applyGeometryVariables();
     ensureDayHeaders();
     layoutTimeline();
     normalizeTaskGeometry();
-    document.body.setAttribute('data-plan-time-grid-version', VERSION);
+    if (document.body) {
+      document.body.setAttribute('data-plan-time-grid-version', VERSION);
+    }
+  }
+
+  function queueSynchronize() {
+    if (synchronizeQueued) {
+      return;
+    }
+    synchronizeQueued = true;
+    window.requestAnimationFrame(synchronize);
   }
 
   function topForClock(hours, minutes) {
@@ -132,7 +161,9 @@
       gridHeight: containerRect.height,
       sixCenter: sixRect.top + sixRect.height / 2,
       sevenCenter: sevenRect.top + sevenRect.height / 2,
-      hourDistance: sevenRect.top - sixRect.top
+      hourDistance:
+        sevenRect.top + sevenRect.height / 2 -
+        (sixRect.top + sixRect.height / 2)
     };
   }
 
@@ -154,16 +185,15 @@
 
     const calendar = document.querySelector('.calendar');
     if (calendar) {
-      new MutationObserver(function () {
-        window.requestAnimationFrame(synchronize);
-      }).observe(calendar, { childList: true, subtree: true });
+      new MutationObserver(queueSynchronize).observe(calendar, {
+        childList: true,
+        subtree: true
+      });
     }
 
-    window.addEventListener('resize', function () {
-      window.requestAnimationFrame(synchronize);
-    });
-    window.addEventListener('plan:interactions-ready', synchronize);
-    window.addEventListener('plan:drag-surface-ready', synchronize);
+    window.addEventListener('resize', queueSynchronize);
+    window.addEventListener('plan:interactions-ready', queueSynchronize);
+    window.addEventListener('plan:drag-surface-ready', queueSynchronize);
     window.dispatchEvent(new CustomEvent('plan:time-grid-ready'));
   }
 

--- a/plans/test_lesson_catalog.py
+++ b/plans/test_lesson_catalog.py
@@ -1,0 +1,150 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from accounts.models import Student
+from plans.default_plan_data import ensure_advisor_for_user, seed_plan_defaults
+from plans.lesson_catalog import allowed_grade_names, sort_lessons_for_student
+from plans.models import Chapter, Lesson, LessonType
+
+
+class PlanLessonCatalogRulesTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="lesson-rules-admin",
+            email="lesson-rules@example.com",
+            password="test-password",
+        )
+        advisor = ensure_advisor_for_user(self.admin)
+        seed_plan_defaults(advisor=advisor)
+        self.client.force_login(self.admin)
+
+        self.math_student = Student.objects.select_related("grade", "major").get(
+            profile__user__username="demo_plan_student_r"
+        )
+        self.experimental_student = Student.objects.select_related("grade", "major").get(
+            profile__user__username="demo_plan_student_t"
+        )
+
+        specialized, _ = LessonType.objects.get_or_create(name="اختصاصی")
+        general, _ = LessonType.objects.get_or_create(name="عمومی")
+        grades = {
+            student.grade.name: student.grade
+            for student in Student.objects.select_related("grade").all()
+        }
+
+        self.math_tenth = Lesson.objects.create(
+            subject_code="RULE-R10",
+            name="درس ریاضی پایه قبل",
+            lesson_type=specialized,
+            grade=grades["دهم"],
+        )
+        Chapter.objects.create(
+            chapter_number=1,
+            name="فصل ریاضی دهم",
+            lesson=self.math_tenth,
+            track="R",
+        )
+
+        self.math_eleventh = Lesson.objects.create(
+            subject_code="RULE-R11",
+            name="درس ریاضی پایه جاری",
+            lesson_type=specialized,
+            grade=grades["یازدهم"],
+        )
+        Chapter.objects.create(
+            chapter_number=1,
+            name="فصل ریاضی یازدهم",
+            lesson=self.math_eleventh,
+            track="R",
+        )
+
+        self.math_twelfth = Lesson.objects.create(
+            subject_code="RULE-R12",
+            name="درس ریاضی پایه آینده",
+            lesson_type=specialized,
+            grade=grades["دوازدهم"],
+        )
+        Chapter.objects.create(
+            chapter_number=1,
+            name="فصل ریاضی دوازدهم",
+            lesson=self.math_twelfth,
+            track="R",
+        )
+
+        self.experimental_eleventh = Lesson.objects.create(
+            subject_code="RULE-T11",
+            name="درس اختصاصی تجربی",
+            lesson_type=specialized,
+            grade=grades["یازدهم"],
+        )
+        Chapter.objects.create(
+            chapter_number=1,
+            name="فصل تجربی یازدهم",
+            lesson=self.experimental_eleventh,
+            track="T",
+        )
+
+        self.math_general = Lesson.objects.create(
+            subject_code="RULE-RG11",
+            name="درس عمومی ریاضی",
+            lesson_type=general,
+            grade=grades["یازدهم"],
+        )
+        Chapter.objects.create(
+            chapter_number=1,
+            name="فصل عمومی ریاضی",
+            lesson=self.math_general,
+            track="R",
+        )
+
+    def test_allowed_grades_include_current_and_completed_lower_grades(self):
+        self.assertEqual(
+            allowed_grade_names(self.math_student),
+            {"دهم", "یازدهم"},
+        )
+        self.assertEqual(
+            allowed_grade_names(self.experimental_student),
+            {"دهم", "یازدهم", "دوازدهم"},
+        )
+
+    def test_catalog_excludes_future_grade_and_other_major(self):
+        catalog = sort_lessons_for_student(self.math_student)
+        specialized_ids = {lesson.pk for lesson in catalog["specialized_lessons"]}
+        general_ids = {lesson.pk for lesson in catalog["general_lessons"]}
+
+        self.assertIn(self.math_tenth.pk, specialized_ids)
+        self.assertIn(self.math_eleventh.pk, specialized_ids)
+        self.assertNotIn(self.math_twelfth.pk, specialized_ids)
+        self.assertNotIn(self.experimental_eleventh.pk, specialized_ids)
+        self.assertIn(self.math_general.pk, general_ids)
+
+    def test_lesson_endpoint_returns_authoritative_grade_toolbar_rules(self):
+        response = self.client.get(
+            "/get-lessons-for-student/",
+            {"student_id": self.math_student.pk},
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        payload = response.json()
+
+        self.assertEqual(payload["major_code"], "R")
+        self.assertEqual(payload["student_grade"], "یازدهم")
+        self.assertEqual(payload["student_grade_id"], self.math_student.grade_id)
+
+        allowed_names = {
+            option["name"]
+            for option in payload["grade_options"]
+            if option["id"] in payload["allowed_grade_ids"]
+        }
+        self.assertEqual(allowed_names, {"دهم", "یازدهم"})
+
+        returned_ids = {
+            lesson["id"]
+            for lesson in payload["specialized_lessons"]
+            + payload["general_lessons"]
+        }
+        self.assertIn(self.math_tenth.pk, returned_ids)
+        self.assertIn(self.math_eleventh.pk, returned_ids)
+        self.assertIn(self.math_general.pk, returned_ids)
+        self.assertNotIn(self.math_twelfth.pk, returned_ids)
+        self.assertNotIn(self.experimental_eleventh.pk, returned_ids)

--- a/plans/test_plan_secondary.py
+++ b/plans/test_plan_secondary.py
@@ -21,30 +21,38 @@ class PlanSecondaryScriptTests(TestCase):
         self.assertEqual(response.status_code, 200)
         content = response.content
 
-        style = b'/static/plans/plan-interactions.css?v='
+        interaction_style = b'/static/plans/plan-interactions.css?v='
+        grid_style = b'/static/plans/plan-time-grid.css?v='
         runtime = b'/static/plans/plan-runtime.js?v='
         secondary = b'/static/plans/plan-secondary.js?v='
+        grid = b'/static/plans/plan-time-grid.js?v='
         interactions = b'/static/plans/plan-interactions.js?v='
         manual_resize = b'/static/plans/plan-manual-resize.js?v='
         drag_surface = b'/static/plans/plan-drag-surface.js?v='
+        lesson_toolbar = b'/static/plans/plan-lesson-toolbar.js?v='
 
-        for marker in (
-            style,
+        markers = (
+            interaction_style,
+            grid_style,
             runtime,
             secondary,
+            grid,
             interactions,
             manual_resize,
             drag_surface,
-        ):
+            lesson_toolbar,
+        )
+        for marker in markers:
             self.assertEqual(content.count(marker), 1)
 
-        self.assertLess(content.index(style), content.index(runtime))
-        self.assertLess(content.index(runtime), content.index(secondary))
-        self.assertLess(content.index(secondary), content.index(interactions))
-        self.assertLess(content.index(interactions), content.index(manual_resize))
-        self.assertLess(content.index(manual_resize), content.index(drag_surface))
-        self.assertLess(content.index(drag_surface), content.rfind(b"</body>"))
+        for earlier, later in zip(markers, markers[1:]):
+            self.assertLess(content.index(earlier), content.index(later))
+        self.assertLess(content.index(lesson_toolbar), content.rfind(b"</body>"))
+
         self.assertIn(b'data-plan-interactions="true"', content)
         self.assertIn(b'data-plan-manual-resize="true"', content)
         self.assertIn(b'data-plan-drag-surface="true"', content)
+        self.assertIn(b'data-plan-time-grid="true"', content)
+        self.assertIn(b'data-plan-lesson-toolbar="true"', content)
         self.assertIn(b'data-plan-interactions-style="true"', content)
+        self.assertIn(b'data-plan-time-grid-style="true"', content)


### PR DESCRIPTION
## مشکل ساعت و جای باکس‌ها
Template قدیمی برای Timeline، Header روز و Task Container سه هندسه جدا داشت:
- Timeline با margin ثابت 50px
- Day Column با padding و header متغیر
- Grid پس‌زمینه هر 15px، در حالی که Drag روی 8.75px snap می‌شد

### اصلاح اساسی
- یک هندسه مرجع برای کل تقویم: 06:00 تا 00:00
- 35px برای هر ساعت و 8.75px برای هر 15 دقیقه
- Grid روز دقیقاً 630px
- Header همه روزها ارتفاع ثابت و مشترک دارد
- 06:00 خط‌کش دقیقاً مبدأ Task Container است
- خطوط اصلی ساعتی و خطوط فرعی 15 دقیقه‌ای از همان مقیاس ساخته می‌شوند
- Drop، Resize، Label زمان و باکس‌های ذخیره‌شده با همان مختصات قبلی 35px/hour سازگار می‌مانند

## قواعد نوار دروس
- فیلتر رشته همچنان از Track فصل‌ها (`T/R/E`) اعمال می‌شود
- دهم: فقط درس‌های دهم
- یازدهم: درس‌های دهم و یازدهم
- دوازدهم: درس‌های دهم، یازدهم و دوازدهم
- درس پایه آینده از Backend برگردانده نمی‌شود
- Checkbox پایه‌های مجاز فعال و تیک‌خورده است؛ پایه آینده غیرفعال است
- تفکیک تخصصی/عمومی، ترتیب دروس و رنگ‌ها حفظ شده است

## تست‌ها
- Unit test برای رشته و پایه
- بررسی ترتیب Assetها
- Playwright واقعی روی Production:
  - تطابق مبدأ 06:00 با Grid
  - فاصله دقیق 35px بین ساعت‌ها
  - مدرسه 07:30–14:00 در Top و Height صحیح
  - دانش‌آموز ریاضی یازدهم فقط پایه دهم/یازدهم و بدون درس زیست
  - Drop درس روی ساعت 12:00 و Label صحیح 12:00–13:30