### PR TITLE
Keep same-day calendar tasks independent

### DIFF
--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -10,6 +10,7 @@ on:
       - 'deploy/plan_real_interaction_e2e.py'
       - 'deploy/plan_school_drag_e2e.py'
       - 'deploy/plan_time_grid_e2e.py'
+      - 'deploy/plan_task_independence_e2e.py'
       - 'config/test_settings.py'
       - '.github/workflows/deploy.yml'
       - '.github/workflows/validate-plan.yml'
@@ -37,12 +38,14 @@ jobs:
           node --check plans/static/plans/plan-manual-resize.js
           node --check plans/static/plans/plan-drag-surface.js
           node --check plans/static/plans/plan-lesson-toolbar.js
+          node --check plans/static/plans/plan-task-geometry.js
           python3 -m py_compile \
             deploy/plan_e2e.py \
             deploy/plan_e2e_runner.py \
             deploy/plan_real_interaction_e2e.py \
             deploy/plan_school_drag_e2e.py \
             deploy/plan_time_grid_e2e.py \
+            deploy/plan_task_independence_e2e.py \
             plans/management/commands/cleanup_plan_demo_reports.py \
             plans/lesson_catalog.py \
             plans/plan_page.py \

--- a/.github/workflows/verify-plan-interactions.yml
+++ b/.github/workflows/verify-plan-interactions.yml
@@ -15,7 +15,7 @@ jobs:
   verify-real-interactions:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
 
     steps:
       - name: Checkout deployed commit
@@ -43,6 +43,8 @@ jobs:
           PLAN_SCHOOL_TEST_WEEK: 1499-03-01
           PLAN_GRID_STUDENT_LABEL: نمونه ریاضی یازدهم
           PLAN_GRID_TEST_WEEK: 1405-09-01
+          PLAN_GEOMETRY_STUDENT_LABEL: نمونه ریاضی یازدهم
+          PLAN_GEOMETRY_TEST_WEEK: 1405-09-01
         run: |
           set +e
           export PLAN_USERNAME="${PLAN_USERNAME:-admin}"
@@ -59,15 +61,21 @@ jobs:
             > plan-time-grid-output.txt 2>&1
           grid_status=$?
 
+          .plan-real-browser-venv/bin/python deploy/plan_task_independence_e2e.py \
+            > plan-task-independence-output.txt 2>&1
+          independence_status=$?
+
           echo '===== Core real interactions ====='
           cat plan-real-interaction-output.txt
           echo '===== School-block drag interactions ====='
           cat plan-school-drag-output.txt
           echo '===== Time grid and lesson toolbar ====='
           cat plan-time-grid-output.txt
+          echo '===== Same-day task independence ====='
+          cat plan-task-independence-output.txt
 
           status=0
-          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ]; then
+          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ] || [ "$independence_status" -ne 0 ]; then
             status=1
           fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
@@ -82,6 +90,7 @@ jobs:
             plan-real-interaction-output.txt
             plan-school-drag-output.txt
             plan-time-grid-output.txt
+            plan-task-independence-output.txt
           retention-days: 3
 
       - name: Publish real interaction status
@@ -97,10 +106,10 @@ jobs:
           set -euo pipefail
           if [ "${TEST_STATUS:-1}" = "0" ]; then
             STATE='success'
-            DESCRIPTION='Plan drag, resize, school blocks, time grid and lesson rules passed.'
+            DESCRIPTION='Plan interactions, time grid and independent same-day tasks passed.'
           else
             STATE='failure'
-            DESCRIPTION='Plan interaction, time-grid or lesson-toolbar regression failed.'
+            DESCRIPTION='Plan interaction, time-grid or task-independence regression failed.'
           fi
 
           jq -n \

--- a/deploy/plan_task_independence_e2e.py
+++ b/deploy/plan_task_independence_e2e.py
@@ -139,25 +139,14 @@ def main() -> int:
         ).first
         require(first.count() == 1 and second.count() == 1, "two study tasks were added to one day")
 
-        positions = page.evaluate(
-            """
-            ([first, second]) => ({
-              first: getComputedStyle(first).position,
-              second: getComputedStyle(second).position,
-              firstTop: first.getBoundingClientRect().top,
-              secondTop: second.getBoundingClientRect().top,
-              firstHeight: first.getBoundingClientRect().height,
-              secondCssTop: parseFloat(second.style.top || '0')
-            })
-            """,
-            [first.element_handle(), second.element_handle()],
-        )
-        require(positions["first"] == "absolute", "first new task is absolutely positioned")
-        require(positions["second"] == "absolute", "second new task is absolutely positioned")
+        first_position = first.evaluate("element => getComputedStyle(element).position")
+        second_position = second.evaluate("element => getComputedStyle(element).position")
+        require(first_position == "absolute", "first new task is absolutely positioned")
+        require(second_position == "absolute", "second new task is absolutely positioned")
 
         second_before_resize = box(second)["y"]
-        second_css_top_before = page.evaluate(
-            "element => parseFloat(element.style.top || '0')", second.element_handle()
+        second_css_top_before = second.evaluate(
+            "element => parseFloat(element.style.top || '0')"
         )
         first_height_before = box(first)["height"]
 
@@ -179,8 +168,8 @@ def main() -> int:
 
         first_height_after = box(first)["height"]
         second_after_resize = box(second)["y"]
-        second_css_top_after = page.evaluate(
-            "element => parseFloat(element.style.top || '0')", second.element_handle()
+        second_css_top_after = second.evaluate(
+            "element => parseFloat(element.style.top || '0')"
         )
         require(
             first_height_after >= first_height_before + 50,
@@ -205,10 +194,7 @@ def main() -> int:
             "deleting the first task does not move the second task",
         )
         require(
-            page.evaluate(
-                "element => getComputedStyle(element).position", second.element_handle()
-            )
-            == "absolute",
+            second.evaluate("element => getComputedStyle(element).position") == "absolute",
             "remaining task stays absolutely positioned after sibling deletion",
         )
 

--- a/deploy/plan_task_independence_e2e.py
+++ b/deploy/plan_task_independence_e2e.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import os
+import sys
+from urllib.parse import urljoin
+
+from playwright.sync_api import Locator, Page, sync_playwright
+
+
+BASE_URL = os.environ.get(
+    "PLAN_BASE_URL", "https://panel.kimiagarkhoone.com"
+).rstrip("/") + "/"
+USERNAME = os.environ.get("PLAN_USERNAME", "").strip()
+PASSWORD = os.environ.get("PLAN_PASSWORD", "")
+TEST_WEEK = os.environ.get("PLAN_GEOMETRY_TEST_WEEK", "1405-09-01")
+STUDENT_LABEL = os.environ.get(
+    "PLAN_GEOMETRY_STUDENT_LABEL", "نمونه ریاضی یازدهم"
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+    print(f"PASS: {message}")
+
+
+def box(locator: Locator) -> dict[str, float]:
+    value = locator.bounding_box()
+    if not value:
+        raise AssertionError("Element has no visible bounding box")
+    return value
+
+
+def drag_palette_to(page: Page, source: Locator, target: Locator, y_offset: float) -> None:
+    source.scroll_into_view_if_needed()
+    source_box = box(source)
+    target_box = box(target)
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2,
+        source_box["y"] + source_box["height"] / 2,
+    )
+    page.mouse.down()
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2 + 8,
+        source_box["y"] + source_box["height"] / 2 + 8,
+        steps=4,
+    )
+    page.mouse.move(
+        target_box["x"] + target_box["width"] / 2,
+        target_box["y"] + y_offset,
+        steps=30,
+    )
+    page.mouse.up()
+    page.wait_for_timeout(450)
+
+
+def load_week(page: Page) -> None:
+    page.select_option("#student-select", label=STUDENT_LABEL)
+    page.evaluate(
+        """
+        value => {
+          window.jQuery('#weekSelector')
+            .val(value)
+            .trigger('input')
+            .trigger('change');
+        }
+        """,
+        TEST_WEEK,
+    )
+    page.click("#loadWeek")
+    page.wait_for_function(
+        "window.planRuntimeState && window.planRuntimeState.loaded && "
+        "!window.planRuntimeState.loading",
+        timeout=30_000,
+    )
+    page.wait_for_function(
+        "window.planTaskGeometry && "
+        "document.body.dataset.planTaskGeometryVersion",
+        timeout=15_000,
+    )
+    page.wait_for_timeout(250)
+
+
+def main() -> int:
+    if not USERNAME or not PASSWORD:
+        print("PLAN_USERNAME and PLAN_PASSWORD are required.", file=sys.stderr)
+        return 2
+
+    page_errors: list[str] = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(
+            locale="fa-IR",
+            viewport={"width": 1800, "height": 1050},
+        )
+        page = context.new_page()
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        page.on("dialog", lambda dialog: dialog.accept())
+
+        page.goto(
+            urljoin(BASE_URL, "login/"),
+            wait_until="domcontentloaded",
+            timeout=30_000,
+        )
+        page.fill("#username", USERNAME)
+        page.fill("#password", PASSWORD)
+        page.click('form button[type="submit"]')
+        page.wait_for_url("**/plan/", timeout=30_000)
+        page.wait_for_function("window.jQuery && window.jQuery.ui", timeout=20_000)
+        load_week(page)
+
+        containers = page.locator(".calendar .task-container")
+        target = None
+        for index in range(containers.count()):
+            candidate = containers.nth(index)
+            if candidate.locator(":scope > .calendar-task").count() == 0:
+                target = candidate
+                break
+        require(target is not None, "an empty day column is available")
+
+        palette = page.locator(".subjects-box .plan-lesson-palette:visible")
+        require(palette.count() >= 2, "two visible lesson cards are available")
+
+        first_source = palette.nth(0)
+        second_source = palette.nth(1)
+        first_id = first_source.get_attribute("data-lesson-id")
+        second_id = second_source.get_attribute("data-lesson-id")
+        require(bool(first_id and second_id), "lesson cards expose stable lesson ids")
+
+        drag_palette_to(page, first_source, target, 175)
+        drag_palette_to(page, second_source, target, 420)
+
+        first = target.locator(
+            f':scope > .calendar-task[data-lesson-id="{first_id}"]'
+        ).first
+        second = target.locator(
+            f':scope > .calendar-task[data-lesson-id="{second_id}"]'
+        ).first
+        require(first.count() == 1 and second.count() == 1, "two study tasks were added to one day")
+
+        positions = page.evaluate(
+            """
+            ([first, second]) => ({
+              first: getComputedStyle(first).position,
+              second: getComputedStyle(second).position,
+              firstTop: first.getBoundingClientRect().top,
+              secondTop: second.getBoundingClientRect().top,
+              firstHeight: first.getBoundingClientRect().height,
+              secondCssTop: parseFloat(second.style.top || '0')
+            })
+            """,
+            [first.element_handle(), second.element_handle()],
+        )
+        require(positions["first"] == "absolute", "first new task is absolutely positioned")
+        require(positions["second"] == "absolute", "second new task is absolutely positioned")
+
+        second_before_resize = box(second)["y"]
+        second_css_top_before = page.evaluate(
+            "element => parseFloat(element.style.top || '0')", second.element_handle()
+        )
+        first_height_before = box(first)["height"]
+
+        handle = first.locator(":scope > .plan-resize-handle")
+        require(handle.count() == 1, "first task has a resize handle")
+        handle_box = box(handle)
+        page.mouse.move(
+            handle_box["x"] + handle_box["width"] / 2,
+            handle_box["y"] + handle_box["height"] / 2,
+        )
+        page.mouse.down()
+        page.mouse.move(
+            handle_box["x"] + handle_box["width"] / 2,
+            handle_box["y"] + handle_box["height"] / 2 + 70,
+            steps=20,
+        )
+        page.mouse.up()
+        page.wait_for_timeout(350)
+
+        first_height_after = box(first)["height"]
+        second_after_resize = box(second)["y"]
+        second_css_top_after = page.evaluate(
+            "element => parseFloat(element.style.top || '0')", second.element_handle()
+        )
+        require(
+            first_height_after >= first_height_before + 50,
+            "resizing the first task changes its own height",
+        )
+        require(
+            abs(second_after_resize - second_before_resize) <= 1.0,
+            "resizing the first task does not move the second task",
+        )
+        require(
+            abs(second_css_top_after - second_css_top_before) <= 0.1,
+            "resizing the first task does not alter the second task top state",
+        )
+
+        second_before_delete = box(second)["y"]
+        first.locator(":scope > .remove-btn").click()
+        page.wait_for_timeout(250)
+        require(first.count() == 0, "first task was removed")
+        second_after_delete = box(second)["y"]
+        require(
+            abs(second_after_delete - second_before_delete) <= 1.0,
+            "deleting the first task does not move the second task",
+        )
+        require(
+            page.evaluate(
+                "element => getComputedStyle(element).position", second.element_handle()
+            )
+            == "absolute",
+            "remaining task stays absolutely positioned after sibling deletion",
+        )
+
+        require(
+            not page_errors,
+            "same-day task independence has no uncaught JavaScript errors: "
+            + " | ".join(page_errors),
+        )
+
+        context.close()
+        browser.close()
+
+    print("Plan task independence regression completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,10 +6,11 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260722-5"
+ASSET_VERSION = "20260722-6"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
     ("plans/plan-time-grid.css", "data-plan-time-grid-style"),
+    ("plans/plan-task-geometry.css", "data-plan-task-geometry-style"),
 )
 RUNTIME_PATHS = (
     ("plans/plan-runtime.js", "data-plan-runtime"),
@@ -19,6 +20,7 @@ RUNTIME_PATHS = (
     ("plans/plan-manual-resize.js", "data-plan-manual-resize"),
     ("plans/plan-drag-surface.js", "data-plan-drag-surface"),
     ("plans/plan-lesson-toolbar.js", "data-plan-lesson-toolbar"),
+    ("plans/plan-task-geometry.js", "data-plan-task-geometry"),
 )
 
 

--- a/plans/static/plans/plan-task-geometry.css
+++ b/plans/static/plans/plan-task-geometry.css
@@ -1,0 +1,15 @@
+.calendar .task-container > .calendar-task {
+  position: absolute !important;
+  display: block !important;
+  margin: 0 !important;
+  box-sizing: border-box !important;
+  flex: none !important;
+  float: none !important;
+}
+
+.calendar .task-container > .calendar-task.ui-draggable,
+.calendar .task-container > .calendar-task.ui-resizable,
+.calendar .task-container > .calendar-task.plan-study-editing,
+.calendar .task-container > .calendar-task.plan-study-editor-pinned {
+  position: absolute !important;
+}

--- a/plans/static/plans/plan-task-geometry.js
+++ b/plans/static/plans/plan-task-geometry.js
@@ -1,0 +1,221 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$) {
+    return;
+  }
+
+  const PIXELS_PER_MINUTE = 35 / 60;
+  const GRID_PIXELS = 8.75;
+  const DEFAULT_DURATION_MINUTES = 90;
+  const VERSION = '2026.07.22.1';
+
+  function finite(value) {
+    const number = Number.parseFloat(value);
+    return Number.isFinite(number) ? number : null;
+  }
+
+  function snap(value) {
+    return Math.round(Number(value || 0) / GRID_PIXELS) * GRID_PIXELS;
+  }
+
+  function inlineNumber(element, property) {
+    if (!element) {
+      return null;
+    }
+    return finite(element.style[property]);
+  }
+
+  function renderedNumber($task, property) {
+    return finite($task.css(property));
+  }
+
+  function currentTop($task) {
+    const element = $task[0];
+    const inline = inlineNumber(element, 'top');
+    if (inline !== null) {
+      return inline;
+    }
+    const rendered = renderedNumber($task, 'top');
+    return rendered !== null ? rendered : 0;
+  }
+
+  function currentHeight($task) {
+    const element = $task[0];
+    const inline = inlineNumber(element, 'height');
+    if (inline !== null && inline > 0) {
+      return inline;
+    }
+    const duration = finite($task.attr('data-duration-minutes'));
+    if (duration !== null && duration > 0) {
+      return duration * PIXELS_PER_MINUTE;
+    }
+    const rendered = renderedNumber($task, 'height');
+    if (rendered !== null && rendered > 0) {
+      return rendered;
+    }
+    return DEFAULT_DURATION_MINUTES * PIXELS_PER_MINUTE;
+  }
+
+  function setAbsoluteGeometry($task, top, height) {
+    const element = $task[0];
+    if (!element) {
+      return;
+    }
+
+    const safeTop = Math.max(0, snap(top));
+    const safeHeight = Math.max(GRID_PIXELS, snap(height));
+
+    element.style.setProperty('position', 'absolute', 'important');
+    element.style.setProperty('display', 'block', 'important');
+    element.style.setProperty('margin', '0', 'important');
+    element.style.setProperty('top', safeTop + 'px');
+    element.style.setProperty('height', safeHeight + 'px');
+    element.style.setProperty('box-sizing', 'border-box', 'important');
+
+    $task
+      .attr('data-plan-top-px', String(safeTop))
+      .attr('data-plan-height-px', String(safeHeight))
+      .attr('data-duration-minutes', String(Math.round(safeHeight / PIXELS_PER_MINUTE)))
+      .attr('data-plan-task-geometry-version', VERSION);
+
+    if (typeof window.updateTimeLabel === 'function') {
+      window.updateTimeLabel($task);
+    }
+  }
+
+  function adoptCurrentGeometry(task) {
+    const $task = $(task);
+    if (!$task.length || !$task.hasClass('calendar-task')) {
+      return;
+    }
+    setAbsoluteGeometry($task, currentTop($task), currentHeight($task));
+  }
+
+  function restoreStoredGeometry(task) {
+    const $task = $(task);
+    if (!$task.length || !$task.hasClass('calendar-task')) {
+      return;
+    }
+    const top = finite($task.attr('data-plan-top-px'));
+    const height = finite($task.attr('data-plan-height-px'));
+    setAbsoluteGeometry(
+      $task,
+      top !== null ? top : currentTop($task),
+      height !== null ? height : currentHeight($task)
+    );
+  }
+
+  function wrapTaskInitializer() {
+    const previous = window.initCalendarTask;
+    if (typeof previous !== 'function' || previous.planTaskGeometryWrapped) {
+      return;
+    }
+
+    const wrapped = function (task) {
+      const $task = $(task);
+
+      // A newly-created task is often initialized while it is still detached.
+      // Prime an inline absolute position first so jQuery UI cannot convert it
+      // to position:relative and put sibling tasks back into normal document flow.
+      adoptCurrentGeometry($task);
+      const result = previous.apply(this, arguments);
+      adoptCurrentGeometry($task);
+      return result;
+    };
+
+    wrapped.planTaskGeometryWrapped = true;
+    wrapped.planTaskGeometryOriginal = previous;
+    window.initCalendarTask = wrapped;
+  }
+
+  function handleAddedNode(node) {
+    if (!node || node.nodeType !== 1) {
+      return;
+    }
+    if (node.matches && node.matches('.calendar-task')) {
+      adoptCurrentGeometry(node);
+    }
+    if (node.querySelectorAll) {
+      node.querySelectorAll('.calendar-task').forEach(adoptCurrentGeometry);
+    }
+  }
+
+  function observeCalendar() {
+    const calendar = document.querySelector('.calendar');
+    if (!calendar) {
+      return;
+    }
+
+    new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        mutation.addedNodes.forEach(handleAddedNode);
+      });
+    }).observe(calendar, {
+      childList: true,
+      subtree: true
+    });
+  }
+
+  function bindInteractionCommits() {
+    $(document)
+      .off('.planTaskGeometry')
+      .on(
+        'dragstart.planTaskGeometry resizestart.planTaskGeometry',
+        '.calendar-task',
+        function () {
+          adoptCurrentGeometry(this);
+          $(this).attr('data-plan-geometry-active', 'true');
+        }
+      )
+      .on(
+        'dragstop.planTaskGeometry resizestop.planTaskGeometry',
+        '.calendar-task',
+        function () {
+          const task = this;
+          window.requestAnimationFrame(function () {
+            adoptCurrentGeometry(task);
+            $(task).removeAttr('data-plan-geometry-active');
+          });
+        }
+      )
+      .on('drop.planTaskGeometry', '.task-container', function () {
+        const container = this;
+        window.requestAnimationFrame(function () {
+          $(container).children('.calendar-task').each(function () {
+            adoptCurrentGeometry(this);
+          });
+        });
+      });
+  }
+
+  function initialize() {
+    wrapTaskInitializer();
+    bindInteractionCommits();
+    $('.calendar .calendar-task').each(function () {
+      adoptCurrentGeometry(this);
+    });
+    observeCalendar();
+
+    window.planTaskGeometry = {
+      version: VERSION,
+      adopt: adoptCurrentGeometry,
+      restore: restoreStoredGeometry,
+      snapshot: function (task) {
+        const $task = $(task);
+        return {
+          position: $task.css('position'),
+          top: currentTop($task),
+          height: currentHeight($task),
+          storedTop: finite($task.attr('data-plan-top-px')),
+          storedHeight: finite($task.attr('data-plan-height-px'))
+        };
+      }
+    };
+
+    document.body.setAttribute('data-plan-task-geometry-version', VERSION);
+    window.dispatchEvent(new CustomEvent('plan:task-geometry-ready'));
+  }
+
+  $(initialize);
+})(window, document, window.jQuery);

--- a/plans/test_plan_secondary.py
+++ b/plans/test_plan_secondary.py
@@ -23,6 +23,7 @@ class PlanSecondaryScriptTests(TestCase):
 
         interaction_style = b'/static/plans/plan-interactions.css?v='
         grid_style = b'/static/plans/plan-time-grid.css?v='
+        geometry_style = b'/static/plans/plan-task-geometry.css?v='
         runtime = b'/static/plans/plan-runtime.js?v='
         secondary = b'/static/plans/plan-secondary.js?v='
         grid = b'/static/plans/plan-time-grid.js?v='
@@ -30,10 +31,12 @@ class PlanSecondaryScriptTests(TestCase):
         manual_resize = b'/static/plans/plan-manual-resize.js?v='
         drag_surface = b'/static/plans/plan-drag-surface.js?v='
         lesson_toolbar = b'/static/plans/plan-lesson-toolbar.js?v='
+        task_geometry = b'/static/plans/plan-task-geometry.js?v='
 
         markers = (
             interaction_style,
             grid_style,
+            geometry_style,
             runtime,
             secondary,
             grid,
@@ -41,18 +44,21 @@ class PlanSecondaryScriptTests(TestCase):
             manual_resize,
             drag_surface,
             lesson_toolbar,
+            task_geometry,
         )
         for marker in markers:
             self.assertEqual(content.count(marker), 1)
 
         for earlier, later in zip(markers, markers[1:]):
             self.assertLess(content.index(earlier), content.index(later))
-        self.assertLess(content.index(lesson_toolbar), content.rfind(b"</body>"))
+        self.assertLess(content.index(task_geometry), content.rfind(b"</body>"))
 
         self.assertIn(b'data-plan-interactions="true"', content)
         self.assertIn(b'data-plan-manual-resize="true"', content)
         self.assertIn(b'data-plan-drag-surface="true"', content)
         self.assertIn(b'data-plan-time-grid="true"', content)
         self.assertIn(b'data-plan-lesson-toolbar="true"', content)
+        self.assertIn(b'data-plan-task-geometry="true"', content)
         self.assertIn(b'data-plan-interactions-style="true"', content)
         self.assertIn(b'data-plan-time-grid-style="true"', content)
+        self.assertIn(b'data-plan-task-geometry-style="true"', content)


### PR DESCRIPTION
## Root cause
New calendar tasks were initialized by jQuery UI while still detached from the calendar. In that state, jQuery UI could convert the task to `position: relative`. Multiple tasks in one day then re-entered normal document flow:
- increasing the first task height pushed the second task down by the exact same number of pixels
- deleting the first task pulled the second task back up

This matches the screenshots exactly.

## Fix
- force every direct calendar task to remain `position: absolute`
- prime absolute geometry before any detached task is passed to Draggable/Resizable
- preserve independent `top` and `height` state per task
- commit each task's geometry only after its own drag/resize/drop
- automatically repair existing relative tasks after deployment
- bump asset version to avoid stale browser cache

## Regression coverage
A new real-browser production test:
1. drops two new lessons into the same day
2. verifies both use absolute positioning
3. resizes the first task by about 70px
4. confirms the second task does not move even 1px and its CSS top is unchanged
5. deletes the first task
6. confirms the remaining task still does not move