### PR TITLE
Fix modern Plan header and palette row layout

### DIFF
--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,12 +6,13 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260722-7"
+ASSET_VERSION = "20260722-8"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
     ("plans/plan-time-grid.css", "data-plan-time-grid-style"),
     ("plans/plan-task-geometry.css", "data-plan-task-geometry-style"),
     ("plans/plan-modern-ui.css", "data-plan-modern-ui-style"),
+    ("plans/plan-modern-ui-fixes.css", "data-plan-modern-ui-fixes-style"),
 )
 RUNTIME_PATHS = (
     ("plans/plan-runtime.js", "data-plan-runtime"),

--- a/plans/static/plans/plan-modern-ui-fixes.css
+++ b/plans/static/plans/plan-modern-ui-fixes.css
@@ -1,0 +1,23 @@
+.plan-ui-modern .nav-bar {
+  display: block !important;
+  width: 100% !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  gap: 0 !important;
+}
+
+.plan-ui-modern .nav-bar > .top-header,
+.plan-ui-modern .nav-bar > .plan-palette-row {
+  width: 100% !important;
+  min-width: 0 !important;
+}
+
+.plan-ui-modern .nav-bar > .plan-palette-row {
+  margin-top: 0 !important;
+}
+
+@media (max-width: 760px) {
+  .plan-ui-modern .nav-bar {
+    overflow: visible !important;
+  }
+}

--- a/plans/test_plan_secondary.py
+++ b/plans/test_plan_secondary.py
@@ -25,6 +25,7 @@ class PlanSecondaryScriptTests(TestCase):
         grid_style = b'/static/plans/plan-time-grid.css?v='
         geometry_style = b'/static/plans/plan-task-geometry.css?v='
         modern_style = b'/static/plans/plan-modern-ui.css?v='
+        modern_fixes_style = b'/static/plans/plan-modern-ui-fixes.css?v='
         runtime = b'/static/plans/plan-runtime.js?v='
         secondary = b'/static/plans/plan-secondary.js?v='
         grid = b'/static/plans/plan-time-grid.js?v='
@@ -40,6 +41,7 @@ class PlanSecondaryScriptTests(TestCase):
             grid_style,
             geometry_style,
             modern_style,
+            modern_fixes_style,
             runtime,
             secondary,
             grid,
@@ -68,3 +70,4 @@ class PlanSecondaryScriptTests(TestCase):
         self.assertIn(b'data-plan-time-grid-style="true"', content)
         self.assertIn(b'data-plan-task-geometry-style="true"', content)
         self.assertIn(b'data-plan-modern-ui-style="true"', content)
+        self.assertIn(b'data-plan-modern-ui-fixes-style="true"', content)


### PR DESCRIPTION
اصلاح تکمیلی بازطراحی Plan:

- خنثی‌کردن `display:flex` قدیمی روی `.nav-bar`
- هدر تمام‌عرض در ردیف اول
- کارت‌های تکالیف و ایونت‌ها در ردیف مستقل و مرتب زیر هدر
- حفظ Responsive موبایل و تبلت
- Cache bust و تست ترتیب Assetها

این تغییر فقط CSS layout است و به هیچ منطق Drag/Drop، Resize، زمان یا ذخیره‌سازی دست نمی‌زند.