### PR TITLE
Fix Dashboard production test argument handling

### DIFF
--- a/deploy/dashboard_e2e.py
+++ b/deploy/dashboard_e2e.py
@@ -32,7 +32,7 @@ def wait_for_content(page: Page, selector: str, minimum: int = 12) -> None:
           );
         }
         """,
-        {"selector": selector, "minimum": minimum},
+        arg={"selector": selector, "minimum": minimum},
         timeout=20_000,
     )
 


### PR DESCRIPTION
تمام APIها و دانلودهای Dashboard روی Production پاس شدند. شکست فقط از نحوه فراخوانی Playwright در خود تست بود: `wait_for_function` آرگومان داده را فقط به‌صورت keyword-only می‌پذیرد.

این PR فقط اسکریپت تست را اصلاح می‌کند و هیچ کد محصولی را تغییر نمی‌دهد.