### PR TITLE
Keep Dashboard chat accessible on mobile

### DIFF
--- a/.github/workflows/validate-dashboard.yml
+++ b/.github/workflows/validate-dashboard.yml
@@ -6,6 +6,9 @@ on:
       - 'accounts/**'
       - 'management/**'
       - 'plans/dashboard_admin.py'
+      - 'plans/dashboard_page.py'
+      - 'plans/static/plans/dashboard-responsive.css'
+      - 'plans/test_dashboard_page.py'
       - 'plans/views.py'
       - 'plans/urls.py'
       - 'plans/templates/plans/management.html'
@@ -35,6 +38,8 @@ jobs:
             management/dashboard_security.py \
             management/test_dashboard.py \
             plans/dashboard_admin.py \
+            plans/dashboard_page.py \
+            plans/test_dashboard_page.py \
             deploy/dashboard_e2e.py \
             deploy/dashboard_e2e_runner.py
 
@@ -54,8 +59,10 @@ jobs:
         shell: bash
         run: |
           set +e
-          .venv/bin/python manage.py test management.test_dashboard --verbosity 2 \
-            > dashboard-test-output.txt 2>&1
+          .venv/bin/python manage.py test \
+            management.test_dashboard \
+            plans.test_dashboard_page \
+            --verbosity 2 > dashboard-test-output.txt 2>&1
           status=$?
           cat dashboard-test-output.txt
           exit "$status"

--- a/plans/dashboard_page.py
+++ b/plans/dashboard_page.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+
+from plans import views
+
+
+ASSET_VERSION = "20260722-1"
+STYLE_ATTRIBUTE = "data-dashboard-responsive-style"
+STYLE_PATH = "plans/dashboard-responsive.css"
+
+
+def _static_url(path: str) -> str:
+    static_url = str(settings.STATIC_URL or "/static/")
+    if not static_url.startswith(("/", "http://", "https://")):
+        static_url = "/" + static_url
+    return f"{static_url.rstrip('/')}/{path}?v={ASSET_VERSION}"
+
+
+def _append_dashboard_assets(response):
+    content_type = response.get("Content-Type", "")
+    if response.status_code != 200 or "text/html" not in content_type:
+        return response
+
+    marker_attribute = f'{STYLE_ATTRIBUTE}="true"'.encode("utf-8")
+    if marker_attribute in response.content:
+        return response
+
+    marker = b"</head>"
+    marker_index = response.content.rfind(marker)
+    if marker_index < 0:
+        raise RuntimeError("The rendered Dashboard page has no closing head tag.")
+
+    style = (
+        f'<link rel="stylesheet" href="{_static_url(STYLE_PATH)}" '
+        f'{STYLE_ATTRIBUTE}="true">\n'
+    ).encode("utf-8")
+    response.content = (
+        response.content[:marker_index]
+        + style
+        + response.content[marker_index:]
+    )
+    response.headers.pop("Content-Length", None)
+    return response
+
+
+@login_required
+def dashboard_view(request):
+    response = views.dashboard_view(request)
+    return _append_dashboard_assets(response)

--- a/plans/static/plans/dashboard-responsive.css
+++ b/plans/static/plans/dashboard-responsive.css
@@ -1,0 +1,46 @@
+/* Dashboard-only responsive safety layer. */
+
+@media (max-width: 640px) {
+  html,
+  body {
+    min-width: 0 !important;
+    max-width: 100% !important;
+  }
+
+  #chat-toggle-btn {
+    display: flex !important;
+    position: fixed !important;
+    left: max(14px, env(safe-area-inset-left)) !important;
+    right: auto !important;
+    bottom: max(14px, env(safe-area-inset-bottom)) !important;
+    width: 56px !important;
+    height: 56px !important;
+    min-width: 56px !important;
+    min-height: 56px !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    transform: none !important;
+    pointer-events: auto !important;
+    z-index: 70 !important;
+  }
+
+  #chat-window {
+    position: fixed !important;
+    left: 12px !important;
+    right: 12px !important;
+    bottom: calc(82px + env(safe-area-inset-bottom)) !important;
+    width: auto !important;
+    max-width: none !important;
+    height: min(520px, calc(100dvh - 108px)) !important;
+    max-height: calc(100dvh - 108px) !important;
+    z-index: 69 !important;
+  }
+
+  #chat-window.hidden {
+    display: none !important;
+  }
+
+  #chat-window:not(.hidden) {
+    display: flex !important;
+  }
+}

--- a/plans/test_dashboard_page.py
+++ b/plans/test_dashboard_page.py
@@ -1,0 +1,31 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from accounts.models import Profile
+
+
+class DashboardResponsiveAssetTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="dashboard-responsive-admin",
+            password="test-password",
+            is_staff=True,
+        )
+        Profile.objects.create(
+            user=self.user,
+            role="admin",
+            first_name="مدیر",
+            last_name="ریسپانسیو",
+        )
+        self.client.force_login(self.user)
+
+    def test_dashboard_responsive_stylesheet_is_injected_once(self):
+        response = self.client.get("/dashboard/")
+        self.assertEqual(response.status_code, 200)
+        content = response.content
+        marker = b'data-dashboard-responsive-style="true"'
+        asset = b'/static/plans/dashboard-responsive.css?v='
+        self.assertEqual(content.count(marker), 1)
+        self.assertEqual(content.count(asset), 1)
+        self.assertLess(content.index(asset), content.rfind(b"</head>"))
+        self.assertContains(response, 'id="chat-toggle-btn"')

--- a/plans/urls.py
+++ b/plans/urls.py
@@ -1,7 +1,7 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from . import dashboard_admin, lesson_catalog, plan_page, weekly_plans_v2
+from . import dashboard_admin, dashboard_page, lesson_catalog, plan_page, weekly_plans_v2
 from .views import *
 
 
@@ -22,7 +22,7 @@ urlpatterns = [
     path("get_default_events/", lesson_catalog.get_default_events, name="get_default_events"),
     path("get-lessons-for-student/", lesson_catalog.get_lessons_for_student, name="get_lessons_for_student"),
     path("get-last-weekly-report/", get_last_weekly_report, name="get_last_weekly_report"),
-    path("dashboard/", dashboard_view, name="dashboard"),
+    path("dashboard/", dashboard_page.dashboard_view, name="dashboard"),
     path("api/admin-panel-data/", get_admin_panel_data, name="api_admin_panel_data"),
     path("api/add-student/", dashboard_admin.add_student_view, name="api_add_student"),
     path("api/admin/advisors/", dashboard_admin.admin_advisors_view, name="api_admin_advisors"),


### PR DESCRIPTION
تست Production یک ایراد واقعی پیدا کرد: در عرض ۳۹۰px، تقویم و پنل‌ها درست بودند اما دکمه ورود به چت از دسترس خارج می‌شد.

اصلاح:
- یک CSS ایمن و Dashboard-only برای موبایل
- دکمه چت همیشه داخل Viewport، با Safe Area و اندازه لمسی مناسب
- پنجره چت در موبایل بین لبه‌های صفحه و بالای دکمه قرار می‌گیرد
- حالت بسته `hidden` و حالت باز `flex` صریح شده‌اند
- Asset از Wrapper جداگانه تزریق می‌شود و Template/منطق چت تغییر نمی‌کند
- تست Asset و تمام Regressionهای Dashboard حفظ شده‌اند