### PR TITLE
Fix advisor chapter loading and restore clear 15-minute drag steps

### DIFF
--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -12,6 +12,7 @@ on:
       - 'deploy/plan_time_grid_e2e.py'
       - 'deploy/plan_task_independence_e2e.py'
       - 'deploy/plan_responsive_ui_e2e.py'
+      - 'deploy/plan_chapter_snap_e2e.py'
       - 'config/test_settings.py'
       - '.github/workflows/deploy.yml'
       - '.github/workflows/validate-plan.yml'
@@ -51,6 +52,7 @@ jobs:
             deploy/plan_time_grid_e2e.py \
             deploy/plan_task_independence_e2e.py \
             deploy/plan_responsive_ui_e2e.py \
+            deploy/plan_chapter_snap_e2e.py \
             plans/management/commands/cleanup_plan_demo_reports.py \
             plans/chapter_catalog.py \
             plans/lesson_catalog.py \

--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -41,6 +41,8 @@ jobs:
           node --check plans/static/plans/plan-lesson-toolbar.js
           node --check plans/static/plans/plan-task-geometry.js
           node --check plans/static/plans/plan-modern-ui.js
+          node --check plans/static/plans/plan-chapter-loader.js
+          node --check plans/static/plans/plan-quarter-snap-feedback.js
           python3 -m py_compile \
             deploy/plan_e2e.py \
             deploy/plan_e2e_runner.py \
@@ -50,6 +52,7 @@ jobs:
             deploy/plan_task_independence_e2e.py \
             deploy/plan_responsive_ui_e2e.py \
             plans/management/commands/cleanup_plan_demo_reports.py \
+            plans/chapter_catalog.py \
             plans/lesson_catalog.py \
             plans/plan_page.py \
             plans/weekly_plans.py \

--- a/.github/workflows/verify-plan-interactions.yml
+++ b/.github/workflows/verify-plan-interactions.yml
@@ -15,7 +15,7 @@ jobs:
   verify-real-interactions:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 45
 
     steps:
       - name: Checkout deployed commit
@@ -69,6 +69,10 @@ jobs:
             > plan-responsive-ui-output.txt 2>&1
           responsive_status=$?
 
+          .plan-real-browser-venv/bin/python deploy/plan_chapter_snap_e2e.py \
+            > plan-chapter-snap-output.txt 2>&1
+          chapter_snap_status=$?
+
           echo '===== Core real interactions ====='
           cat plan-real-interaction-output.txt
           echo '===== School-block drag interactions ====='
@@ -79,9 +83,11 @@ jobs:
           cat plan-task-independence-output.txt
           echo '===== Responsive visual interface ====='
           cat plan-responsive-ui-output.txt
+          echo '===== Chapter loading and quarter-hour feedback ====='
+          cat plan-chapter-snap-output.txt
 
           status=0
-          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ] || [ "$independence_status" -ne 0 ] || [ "$responsive_status" -ne 0 ]; then
+          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ] || [ "$independence_status" -ne 0 ] || [ "$responsive_status" -ne 0 ] || [ "$chapter_snap_status" -ne 0 ]; then
             status=1
           fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
@@ -98,6 +104,7 @@ jobs:
             plan-time-grid-output.txt
             plan-task-independence-output.txt
             plan-responsive-ui-output.txt
+            plan-chapter-snap-output.txt
           retention-days: 3
 
       - name: Publish real interaction status
@@ -113,10 +120,10 @@ jobs:
           set -euo pipefail
           if [ "${TEST_STATUS:-1}" = "0" ]; then
             STATE='success'
-            DESCRIPTION='Plan interactions, time grid, task independence and responsive UI passed.'
+            DESCRIPTION='Plan interactions, chapters, 15-minute snap and responsive UI passed.'
           else
             STATE='failure'
-            DESCRIPTION='Plan interaction, geometry or responsive UI regression failed.'
+            DESCRIPTION='Plan interaction, chapter loading, snap or responsive regression failed.'
           fi
 
           jq -n \

--- a/deploy/plan_chapter_snap_e2e.py
+++ b/deploy/plan_chapter_snap_e2e.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import os
+import sys
+from urllib.parse import urljoin
+
+from playwright.sync_api import Locator, Page, sync_playwright
+
+
+BASE_URL = os.environ.get(
+    "PLAN_BASE_URL", "https://panel.kimiagarkhoone.com"
+).rstrip("/") + "/"
+USERNAME = os.environ.get("PLAN_USERNAME", "").strip()
+PASSWORD = os.environ.get("PLAN_PASSWORD", "")
+TEST_WEEK = os.environ.get("PLAN_GRID_TEST_WEEK", "1405-09-01")
+STUDENT_LABEL = os.environ.get(
+    "PLAN_GRID_STUDENT_LABEL", "نمونه ریاضی یازدهم"
+)
+GRID_PIXELS = 8.75
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+    print(f"PASS: {message}")
+
+
+def box(locator: Locator) -> dict[str, float]:
+    value = locator.bounding_box()
+    if not value:
+        raise AssertionError("Element has no visible bounding box")
+    return value
+
+
+def drag_palette_to(page: Page, source: Locator, target: Locator, y_offset: float) -> None:
+    source.scroll_into_view_if_needed()
+    source_box = box(source)
+    target_box = box(target)
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2,
+        source_box["y"] + source_box["height"] / 2,
+    )
+    page.mouse.down()
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2 + 7,
+        source_box["y"] + source_box["height"] / 2 + 7,
+        steps=4,
+    )
+    page.mouse.move(
+        target_box["x"] + target_box["width"] / 2,
+        target_box["y"] + y_offset,
+        steps=30,
+    )
+    page.mouse.up()
+    page.wait_for_timeout(450)
+
+
+def load_week(page: Page) -> None:
+    page.select_option("#student-select", label=STUDENT_LABEL)
+    page.evaluate(
+        """
+        value => {
+          window.jQuery('#weekSelector')
+            .val(value)
+            .trigger('input')
+            .trigger('change');
+        }
+        """,
+        TEST_WEEK,
+    )
+    page.click("#loadWeek")
+    page.wait_for_function(
+        "window.planRuntimeState && window.planRuntimeState.loaded && "
+        "!window.planRuntimeState.loading",
+        timeout=30_000,
+    )
+    page.wait_for_function(
+        "window.planChapterLoader && window.planQuarterSnapFeedback && "
+        "document.body.dataset.planChapterLoaderVersion && "
+        "document.body.dataset.planQuarterSnapVersion",
+        timeout=20_000,
+    )
+    page.wait_for_timeout(250)
+
+
+def main() -> int:
+    if not USERNAME or not PASSWORD:
+        print("PLAN_USERNAME and PLAN_PASSWORD are required.", file=sys.stderr)
+        return 2
+
+    page_errors: list[str] = []
+    failed_requests: list[str] = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(
+            locale="fa-IR",
+            viewport={"width": 1800, "height": 1050},
+        )
+        page = context.new_page()
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        page.on("dialog", lambda dialog: dialog.accept())
+
+        def collect_response(response) -> None:
+            if response.url.endswith("/get-chapters/") and response.status >= 400:
+                failed_requests.append(f"{response.status} {response.url}")
+
+        page.on("response", collect_response)
+        page.goto(
+            urljoin(BASE_URL, "login/"),
+            wait_until="domcontentloaded",
+            timeout=30_000,
+        )
+        page.fill("#username", USERNAME)
+        page.fill("#password", PASSWORD)
+        page.click('form button[type="submit"]')
+        page.wait_for_url("**/plan/", timeout=30_000)
+        page.wait_for_function("window.jQuery && window.jQuery.ui", timeout=20_000)
+        load_week(page)
+
+        containers = page.locator(".calendar .task-container")
+        target = None
+        for index in range(containers.count()):
+            candidate = containers.nth(index)
+            if candidate.locator(":scope > .calendar-task").count() == 0:
+                target = candidate
+                break
+        require(target is not None, "an empty day is available for chapter and snap testing")
+
+        palette = page.locator(".subjects-box .plan-lesson-palette:visible").first
+        require(palette.count() == 1, "a lesson palette item is available")
+        lesson_id = palette.get_attribute("data-lesson-id")
+        require(bool(lesson_id), "palette lesson exposes its database id")
+
+        drag_palette_to(page, palette, target, 245.0)
+        task = target.locator(
+            f':scope > .calendar-task[data-lesson-id="{lesson_id}"]'
+        ).first
+        require(task.count() == 1, "lesson was added to the calendar")
+        page.wait_for_function(
+            """
+            element => Boolean(
+              element &&
+              element.querySelector('.task-chapter[data-plan-chapter-loader-version]')
+            )
+            """,
+            arg=task.element_handle(),
+            timeout=10_000,
+        )
+
+        student_id = page.locator("#student-select").input_value()
+        chapter_response = context.request.get(
+            urljoin(BASE_URL, "get-chapters/"),
+            params={"student_id": student_id, "lesson_id": lesson_id},
+        )
+        require(chapter_response.status == 200, "chapter API accepts selected student and lesson")
+        chapters = chapter_response.json()
+        require(isinstance(chapters, list) and len(chapters) > 0, "chapter API returns real chapters")
+
+        chapter_select = task.locator(".task-chapter")
+        select2 = chapter_select.locator("xpath=following-sibling::*[contains(@class, 'select2-container')]").first
+        require(select2.count() == 1, "chapter Select2 is initialized")
+        select2.click()
+        page.wait_for_function(
+            """
+            () => Array.from(document.querySelectorAll('.select2-results__option'))
+              .some(option => !option.classList.contains('loading-results'))
+            """,
+            timeout=10_000,
+        )
+        option_texts = page.locator(".select2-results__option").all_inner_texts()
+        require(
+            any("فصل" in text or " - " in text for text in option_texts),
+            "opening the chapter dropdown displays chapter options",
+        )
+        page.keyboard.press("Escape")
+
+        drag_grid = task.evaluate(
+            """
+            element => {
+              const instance = window.jQuery(element).draggable('instance');
+              return instance && instance.options ? instance.options.grid : null;
+            }
+            """
+        )
+        require(
+            bool(drag_grid and abs(float(drag_grid[1]) - GRID_PIXELS) <= 0.01),
+            "calendar task drag is configured in exact 15-minute vertical steps",
+        )
+
+        title = task.locator(".task-title").first
+        title_box = box(title)
+        task_box_before = box(task)
+        page.mouse.move(
+            title_box["x"] + title_box["width"] / 2,
+            title_box["y"] + title_box["height"] / 2,
+        )
+        page.mouse.down()
+        page.mouse.move(
+            title_box["x"] + title_box["width"] / 2 + 4,
+            title_box["y"] + title_box["height"] / 2 + 4,
+            steps=3,
+        )
+        page.mouse.move(
+            title_box["x"] + title_box["width"] / 2,
+            title_box["y"] + title_box["height"] / 2 + 24,
+            steps=12,
+        )
+        page.wait_for_function(
+            """
+            () => {
+              const badge = document.querySelector('.plan-quarter-feedback.is-visible');
+              const line = document.querySelector('.plan-quarter-guide-line.is-visible');
+              return Boolean(badge && line && badge.textContent.includes('۱۵ دقیقه'));
+            }
+            """,
+            timeout=5_000,
+        )
+        require(
+            page.locator(".plan-quarter-feedback.is-visible").count() == 1,
+            "live start/end time feedback appears while dragging",
+        )
+        page.mouse.up()
+        page.wait_for_timeout(350)
+
+        task_top = task.evaluate("element => parseFloat(element.style.top || '0')")
+        require(
+            abs(task_top / GRID_PIXELS - round(task_top / GRID_PIXELS)) <= 0.01,
+            "task finishes on a 15-minute grid boundary",
+        )
+        task_box_after = box(task)
+        require(
+            abs(task_box_after["y"] - task_box_before["y"]) >= GRID_PIXELS - 1,
+            "real mouse movement advances the task by at least one visible step",
+        )
+        require(
+            page.locator(".plan-quarter-feedback.is-visible").count() == 0,
+            "drag feedback closes after mouse release",
+        )
+
+        require(not failed_requests, "chapter loading produced no failing requests: " + " | ".join(failed_requests))
+        require(not page_errors, "chapter and snap flow has no uncaught JavaScript errors: " + " | ".join(page_errors))
+
+        context.close()
+        browser.close()
+
+    print("Plan chapter loading and quarter-hour feedback regression completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plans/chapter_catalog.py
+++ b/plans/chapter_catalog.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseBadRequest, JsonResponse
+from django.views.decorators.http import require_GET
+
+from accounts.models import Student
+from plans.lesson_catalog import MAJOR_TO_CODE, _student_is_visible, sort_lessons_for_student
+from plans.models import Chapter, Lesson
+
+
+def _track_codes(value: object) -> set[str]:
+    return {
+        code.strip().upper()
+        for code in str(value or "").split(",")
+        if code.strip()
+    }
+
+
+@login_required
+@require_GET
+def get_chapters(request):
+    """Return the selected lesson's chapters for an authorized student.
+
+    Student grade and major are derived on the server. The browser no longer
+    needs to send a potentially stale grade or major code when switching
+    between an advisor's students.
+    """
+
+    student_id = request.GET.get("student_id")
+    lesson_id = request.GET.get("lesson_id")
+    query = str(request.GET.get("q") or "").strip()
+
+    if not student_id or not lesson_id:
+        return HttpResponseBadRequest("Missing student_id or lesson_id parameter.")
+
+    try:
+        student = Student.objects.select_related("major", "grade").get(pk=student_id)
+    except (Student.DoesNotExist, TypeError, ValueError):
+        return JsonResponse({"error": "دانش‌آموز مورد نظر یافت نشد."}, status=404)
+
+    if not _student_is_visible(request, student):
+        return JsonResponse(
+            {"error": "دسترسی به این دانش‌آموز مجاز نیست."},
+            status=403,
+        )
+
+    try:
+        lesson = (
+            Lesson.objects.select_related("grade", "lesson_type")
+            .prefetch_related("chapter_set")
+            .get(pk=lesson_id)
+        )
+    except (Lesson.DoesNotExist, TypeError, ValueError):
+        return JsonResponse({"error": "درس مورد نظر یافت نشد."}, status=404)
+
+    allowed_lessons = sort_lessons_for_student(student)
+    allowed_ids = {
+        item.pk
+        for item in (
+            allowed_lessons["specialized_lessons"]
+            + allowed_lessons["general_lessons"]
+        )
+    }
+    if lesson.pk not in allowed_ids:
+        return JsonResponse(
+            {"error": "این درس برای پایه یا رشته دانش‌آموز قابل انتخاب نیست."},
+            status=403,
+        )
+
+    major_code = MAJOR_TO_CODE.get(student.major.name, "").upper()
+    chapters = Chapter.objects.filter(lesson=lesson).order_by(
+        "chapter_number", "pk"
+    )
+
+    seen: set[tuple[object, str]] = set()
+    results: list[dict[str, object]] = []
+    for chapter in chapters:
+        codes = _track_codes(chapter.track)
+        if codes and major_code not in codes:
+            continue
+
+        label = f"{chapter.chapter_number} - {chapter.name}"
+        if query and query not in label:
+            continue
+
+        key = (chapter.chapter_number, chapter.name)
+        if key in seen:
+            continue
+        seen.add(key)
+        results.append({"id": chapter.pk, "text": label})
+
+    return JsonResponse(results, safe=False)

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260722-9"
+ASSET_VERSION = "20260802-1"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
     ("plans/plan-time-grid.css", "data-plan-time-grid-style"),
@@ -14,6 +14,7 @@ STYLE_PATHS = (
     ("plans/plan-modern-ui.css", "data-plan-modern-ui-style"),
     ("plans/plan-modern-ui-fixes.css", "data-plan-modern-ui-fixes-style"),
     ("plans/plan-start-state.css", "data-plan-start-state-style"),
+    ("plans/plan-quarter-snap-feedback.css", "data-plan-quarter-snap-feedback-style"),
 )
 RUNTIME_PATHS = (
     ("plans/plan-runtime.js", "data-plan-runtime"),
@@ -26,6 +27,8 @@ RUNTIME_PATHS = (
     ("plans/plan-task-geometry.js", "data-plan-task-geometry"),
     ("plans/plan-modern-ui.js", "data-plan-modern-ui"),
     ("plans/plan-start-state.js", "data-plan-start-state"),
+    ("plans/plan-chapter-loader.js", "data-plan-chapter-loader"),
+    ("plans/plan-quarter-snap-feedback.js", "data-plan-quarter-snap-feedback"),
 )
 
 

--- a/plans/static/plans/plan-chapter-loader.js
+++ b/plans/static/plans/plan-chapter-loader.js
@@ -1,0 +1,175 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$ || !$.fn.select2) {
+    return;
+  }
+
+  const VERSION = '2026.08.02.1';
+  let synchronizeQueued = false;
+
+  function currentStudentId() {
+    const runtimeId = window.planRuntimeState && window.planRuntimeState.studentId;
+    return String(runtimeId || $('#student-select').val() || '').trim();
+  }
+
+  function markError($task, message) {
+    $task
+      .addClass('plan-chapter-load-error')
+      .attr('data-plan-chapter-error', String(message || 'بارگذاری فصل‌ها انجام نشد.'));
+  }
+
+  function clearError($task) {
+    $task
+      .removeClass('plan-chapter-load-error')
+      .removeAttr('data-plan-chapter-error');
+  }
+
+  function configureChapterSelect(task) {
+    const $task = $(task);
+    const $select = $task.find('.task-chapter').first();
+    const lessonId = String($task.attr('data-lesson-id') || '').trim();
+
+    if (!$select.length || !lessonId) {
+      return;
+    }
+    if ($select.attr('data-plan-chapter-loader-version') === VERSION) {
+      return;
+    }
+
+    const selectedValue = String($select.val() || '').trim();
+    const selectedText = String($select.find('option:selected').text() || '').trim();
+
+    if ($select.hasClass('select2-hidden-accessible')) {
+      try {
+        $select.select2('destroy');
+      } catch (_error) {
+        // A partially initialized legacy Select2 should not block recovery.
+      }
+    }
+
+    if (selectedValue && !$select.find('option[value="' + selectedValue.replace(/"/g, '\\"') + '"]').length) {
+      $select.append(new Option(selectedText || selectedValue, selectedValue, true, true));
+    }
+
+    $select.select2({
+      placeholder: 'شماره فصل',
+      dropdownParent: $task,
+      width: '100%',
+      theme: 'bootstrap-5',
+      allowClear: true,
+      language: {
+        errorLoading: function () { return 'بارگذاری فصل‌ها انجام نشد'; },
+        loadingMore: function () { return 'در حال بارگذاری…'; },
+        noResults: function () { return 'فصلی برای این درس پیدا نشد'; },
+        searching: function () { return 'در حال جست‌وجو…'; }
+      },
+      ajax: {
+        url: '/get-chapters/',
+        dataType: 'json',
+        delay: 120,
+        data: function (params) {
+          return {
+            student_id: currentStudentId(),
+            lesson_id: lessonId,
+            q: params.term || ''
+          };
+        },
+        transport: function (params, success, failure) {
+          const request = $.ajax(params);
+          request.done(function (data) {
+            clearError($task);
+            success(data);
+          });
+          request.fail(function (xhr) {
+            const payload = xhr.responseJSON || {};
+            markError($task, payload.error || payload.message || 'بارگذاری فصل‌ها انجام نشد.');
+            failure(xhr);
+          });
+          return request;
+        },
+        processResults: function (data) {
+          return { results: Array.isArray(data) ? data : [] };
+        }
+      }
+    });
+
+    if (selectedValue) {
+      $select.val(selectedValue).trigger('change.select2');
+    }
+
+    $select.attr('data-plan-chapter-loader-version', VERSION);
+  }
+
+  function synchronize() {
+    synchronizeQueued = false;
+    $('.calendar .calendar-task.extended-task').each(function () {
+      configureChapterSelect(this);
+    });
+    if (document.body) {
+      document.body.setAttribute('data-plan-chapter-loader-version', VERSION);
+    }
+  }
+
+  function queueSynchronize() {
+    if (synchronizeQueued) {
+      return;
+    }
+    synchronizeQueued = true;
+    window.requestAnimationFrame(synchronize);
+  }
+
+  function wrapTaskInitializer() {
+    const previous = window.initCalendarTask;
+    if (typeof previous !== 'function' || previous.planChapterLoaderWrapped) {
+      return;
+    }
+
+    const wrapped = function (task) {
+      const result = previous.apply(this, arguments);
+      const element = task && task.jquery ? task[0] : task;
+      if (element) {
+        window.requestAnimationFrame(function () {
+          configureChapterSelect(element);
+        });
+      }
+      return result;
+    };
+    wrapped.planChapterLoaderWrapped = true;
+    wrapped.planChapterLoaderOriginal = previous;
+    window.initCalendarTask = wrapped;
+  }
+
+  function initialize() {
+    wrapTaskInitializer();
+    synchronize();
+
+    const calendar = document.querySelector('.calendar');
+    if (calendar) {
+      new MutationObserver(queueSynchronize).observe(calendar, {
+        childList: true,
+        subtree: true
+      });
+    }
+
+    $(document)
+      .off('change.planChapterStudent', '#student-select')
+      .on('change.planChapterStudent', '#student-select', function () {
+        $('.task-chapter').removeAttr('data-plan-chapter-loader-version');
+        queueSynchronize();
+      });
+
+    window.addEventListener('plan:interactions-ready', function () {
+      wrapTaskInitializer();
+      queueSynchronize();
+    });
+    window.addEventListener('plan:lesson-toolbar-updated', queueSynchronize);
+
+    window.planChapterLoader = {
+      version: VERSION,
+      synchronize: synchronize
+    };
+  }
+
+  $(initialize);
+})(window, document, window.jQuery);

--- a/plans/static/plans/plan-quarter-snap-feedback.css
+++ b/plans/static/plans/plan-quarter-snap-feedback.css
@@ -1,0 +1,117 @@
+.calendar .task-container {
+  background-image:
+    linear-gradient(to bottom, rgba(71, 85, 105, 0.52) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(100, 116, 139, 0.28) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(203, 213, 225, 0.46) 1px, transparent 1px) !important;
+  background-size:
+    100% var(--plan-hour-height),
+    100% calc(var(--plan-hour-height) / 2),
+    100% var(--plan-quarter-height) !important;
+  background-position: 0 0, 0 0, 0 0 !important;
+  background-repeat: repeat-y, repeat-y, repeat-y !important;
+}
+
+.plan-quarter-feedback {
+  position: fixed;
+  z-index: 30050;
+  display: grid;
+  min-width: 160px;
+  padding: 8px 11px;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(5px) scale(0.97);
+  color: #fff;
+  text-align: right;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.24);
+  backdrop-filter: blur(10px);
+  transition: opacity 90ms ease, transform 90ms ease;
+}
+
+.plan-quarter-feedback.is-visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.plan-quarter-feedback strong {
+  font-size: 12px;
+  font-weight: 900;
+  line-height: 1.45;
+  direction: rtl;
+  font-variant-numeric: tabular-nums;
+}
+
+.plan-quarter-feedback span {
+  margin-top: 1px;
+  color: #bfdbfe;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.plan-quarter-guide-line {
+  position: fixed;
+  z-index: 30040;
+  display: block;
+  height: 2px;
+  pointer-events: none;
+  opacity: 0;
+  border-radius: 999px;
+  background: #2563eb;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.88),
+    0 0 12px rgba(37, 99, 235, 0.7);
+  transition: opacity 70ms ease;
+}
+
+.plan-quarter-guide-line::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: -4px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2563eb;
+  transform: translateY(-50%);
+}
+
+.plan-quarter-guide-line.is-visible {
+  opacity: 1;
+}
+
+.calendar .calendar-task.plan-quarter-snapping,
+.plan-drag-ghost {
+  transition: none !important;
+}
+
+.calendar .calendar-task.plan-chapter-load-error {
+  outline: 2px solid rgba(220, 38, 38, 0.58);
+  outline-offset: 1px;
+}
+
+.calendar .calendar-task.plan-chapter-load-error::after {
+  content: attr(data-plan-chapter-error);
+  position: absolute;
+  right: 4px;
+  bottom: calc(100% + 5px);
+  z-index: 120;
+  max-width: 210px;
+  padding: 6px 8px;
+  color: #991b1b;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1.5;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  background: #fff1f2;
+  box-shadow: 0 8px 18px rgba(127, 29, 29, 0.14);
+}
+
+@media (max-width: 760px) {
+  .plan-quarter-feedback {
+    min-width: 148px;
+    padding: 7px 9px;
+  }
+}

--- a/plans/static/plans/plan-quarter-snap-feedback.js
+++ b/plans/static/plans/plan-quarter-snap-feedback.js
@@ -1,0 +1,244 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$ || !$.ui) {
+    return;
+  }
+
+  const BASE_MINUTES = 6 * 60;
+  const PIXELS_PER_MINUTE = 35 / 60;
+  const GRID_MINUTES = 15;
+  const GRID_PIXELS = GRID_MINUTES * PIXELS_PER_MINUTE;
+  const VERSION = '2026.08.02.1';
+  let synchronizeQueued = false;
+
+  function pad(value) {
+    return String(value).padStart(2, '0');
+  }
+
+  function formatClock(totalMinutes) {
+    let value = Math.round(totalMinutes) % (24 * 60);
+    if (value < 0) {
+      value += 24 * 60;
+    }
+    return pad(Math.floor(value / 60)) + ':' + pad(value % 60);
+  }
+
+  function snap(value) {
+    return Math.round(Number(value || 0) / GRID_PIXELS) * GRID_PIXELS;
+  }
+
+  function ensureFeedback() {
+    let $feedback = $('.plan-quarter-feedback').first();
+    if (!$feedback.length) {
+      $feedback = $(
+        '<div class="plan-quarter-feedback" aria-hidden="true">' +
+          '<strong class="plan-quarter-feedback-time"></strong>' +
+          '<span>حرکت پله‌ای ۱۵ دقیقه</span>' +
+        '</div>'
+      ).appendTo('body');
+    }
+
+    let $line = $('.plan-quarter-guide-line').first();
+    if (!$line.length) {
+      $line = $('<div class="plan-quarter-guide-line" aria-hidden="true"></div>').appendTo('body');
+    }
+    return { feedback: $feedback, line: $line };
+  }
+
+  function visibleContainers() {
+    return $('.calendar .task-container').filter(function () {
+      const rect = this.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    }).toArray();
+  }
+
+  function targetContainer(clientX) {
+    const containers = visibleContainers();
+    let closest = null;
+    let closestDistance = Number.POSITIVE_INFINITY;
+
+    containers.forEach(function (container) {
+      const rect = container.getBoundingClientRect();
+      if (clientX >= rect.left && clientX <= rect.right) {
+        closest = container;
+        closestDistance = 0;
+        return;
+      }
+      const distance = Math.min(
+        Math.abs(clientX - rect.left),
+        Math.abs(clientX - rect.right)
+      );
+      if (distance < closestDistance) {
+        closest = container;
+        closestDistance = distance;
+      }
+    });
+    return closest;
+  }
+
+  function updateFeedback(event, $task) {
+    const clientX = Number.isFinite(event.clientX)
+      ? event.clientX
+      : Number(event.pageX || 0) - window.scrollX;
+    const clientY = Number.isFinite(event.clientY)
+      ? event.clientY
+      : Number(event.pageY || 0) - window.scrollY;
+    const container = targetContainer(clientX);
+    if (!container) {
+      return;
+    }
+
+    const rect = container.getBoundingClientRect();
+    const height = Math.max(GRID_PIXELS, $task.outerHeight());
+    const grabOffset = Math.max(0, Number($task.data('planGrabOffsetY')) || 0);
+    const maximum = Math.max(0, rect.height - height);
+    const top = Math.max(0, Math.min(snap(clientY - rect.top - grabOffset), maximum));
+    const start = BASE_MINUTES + Math.round(top / PIXELS_PER_MINUTE);
+    const duration = Math.max(GRID_MINUTES, Math.round(height / PIXELS_PER_MINUTE));
+    const widgets = ensureFeedback();
+
+    widgets.feedback
+      .addClass('is-visible')
+      .css({
+        left: Math.min(window.innerWidth - 178, Math.max(8, clientX + 14)) + 'px',
+        top: Math.max(8, clientY - 54) + 'px'
+      })
+      .find('.plan-quarter-feedback-time')
+      .text(formatClock(start) + ' تا ' + formatClock(start + duration));
+
+    widgets.line
+      .addClass('is-visible')
+      .css({
+        left: rect.left + 'px',
+        top: rect.top + top + 'px',
+        width: rect.width + 'px'
+      });
+  }
+
+  function hideFeedback() {
+    $('.plan-quarter-feedback, .plan-quarter-guide-line').removeClass('is-visible');
+  }
+
+  function draggableInstance($task) {
+    try {
+      return $task.draggable('instance') || null;
+    } catch (_error) {
+      return $task.data('ui-draggable') || null;
+    }
+  }
+
+  function patchTask(task) {
+    const $task = $(task);
+    const instance = draggableInstance($task);
+    if (!instance || !instance.options) {
+      return;
+    }
+    if ($task.attr('data-plan-quarter-snap-version') === VERSION) {
+      return;
+    }
+
+    const options = instance.options;
+    const previousStart = options.start;
+    const previousDrag = options.drag;
+    const previousStop = options.stop;
+
+    options.grid = [1, GRID_PIXELS];
+    options.start = function (event, ui) {
+      const result = typeof previousStart === 'function'
+        ? previousStart.apply(this, arguments)
+        : undefined;
+      $(this).addClass('plan-quarter-snapping');
+      updateFeedback(event, $(this));
+      return result;
+    };
+    options.drag = function (event, ui) {
+      const result = typeof previousDrag === 'function'
+        ? previousDrag.apply(this, arguments)
+        : undefined;
+      updateFeedback(event, $(this));
+      return result;
+    };
+    options.stop = function (event, ui) {
+      try {
+        return typeof previousStop === 'function'
+          ? previousStop.apply(this, arguments)
+          : undefined;
+      } finally {
+        $(this).removeClass('plan-quarter-snapping');
+        hideFeedback();
+      }
+    };
+
+    $task.attr('data-plan-quarter-snap-version', VERSION);
+  }
+
+  function synchronize() {
+    synchronizeQueued = false;
+    $('.calendar .calendar-task').each(function () {
+      patchTask(this);
+    });
+    if (document.body) {
+      document.body.setAttribute('data-plan-quarter-snap-version', VERSION);
+    }
+  }
+
+  function queueSynchronize() {
+    if (synchronizeQueued) {
+      return;
+    }
+    synchronizeQueued = true;
+    window.requestAnimationFrame(synchronize);
+  }
+
+  function wrapTaskInitializer() {
+    const previous = window.initCalendarTask;
+    if (typeof previous !== 'function' || previous.planQuarterSnapWrapped) {
+      return;
+    }
+
+    const wrapped = function (task) {
+      const result = previous.apply(this, arguments);
+      const element = task && task.jquery ? task[0] : task;
+      if (element) {
+        window.requestAnimationFrame(function () {
+          patchTask(element);
+        });
+      }
+      return result;
+    };
+    wrapped.planQuarterSnapWrapped = true;
+    wrapped.planQuarterSnapOriginal = previous;
+    window.initCalendarTask = wrapped;
+  }
+
+  function initialize() {
+    ensureFeedback();
+    wrapTaskInitializer();
+    synchronize();
+
+    const calendar = document.querySelector('.calendar');
+    if (calendar) {
+      new MutationObserver(queueSynchronize).observe(calendar, {
+        childList: true,
+        subtree: true
+      });
+    }
+
+    window.addEventListener('plan:interactions-ready', function () {
+      wrapTaskInitializer();
+      queueSynchronize();
+    });
+    window.addEventListener('blur', hideFeedback);
+    document.addEventListener('mouseup', hideFeedback, true);
+    document.addEventListener('pointerup', hideFeedback, true);
+
+    window.planQuarterSnapFeedback = {
+      version: VERSION,
+      synchronize: synchronize,
+      gridMinutes: GRID_MINUTES
+    };
+  }
+
+  $(initialize);
+})(window, document, window.jQuery);

--- a/plans/test_lesson_catalog.py
+++ b/plans/test_lesson_catalog.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from accounts.models import Student
+from accounts.models import Advisor, Profile, Student
 from plans.default_plan_data import ensure_advisor_for_user, seed_plan_defaults
 from plans.lesson_catalog import allowed_grade_names, sort_lessons_for_student
 from plans.models import Chapter, Lesson, LessonType
@@ -52,7 +52,7 @@ class PlanLessonCatalogRulesTests(TestCase):
             lesson_type=specialized,
             grade=grades["یازدهم"],
         )
-        Chapter.objects.create(
+        self.math_eleventh_chapter = Chapter.objects.create(
             chapter_number=1,
             name="فصل ریاضی یازدهم",
             lesson=self.math_eleventh,
@@ -97,6 +97,18 @@ class PlanLessonCatalogRulesTests(TestCase):
             lesson=self.math_general,
             track="R",
         )
+
+    def make_advisor(self, username: str) -> tuple[object, Advisor]:
+        User = get_user_model()
+        user = User.objects.create_user(username=username, password="test-password")
+        profile = Profile.objects.create(
+            user=user,
+            role="advisor",
+            first_name="مشاور",
+            last_name=username,
+            phone_number=f"09{user.pk:09d}"[-11:],
+        )
+        return user, Advisor.objects.create(profile=profile)
 
     def test_allowed_grades_include_current_and_completed_lower_grades(self):
         self.assertEqual(
@@ -148,3 +160,57 @@ class PlanLessonCatalogRulesTests(TestCase):
         self.assertIn(self.math_general.pk, returned_ids)
         self.assertNotIn(self.math_twelfth.pk, returned_ids)
         self.assertNotIn(self.experimental_eleventh.pk, returned_ids)
+
+    def test_assigned_advisor_loads_chapters_from_student_context(self):
+        advisor_user, advisor = self.make_advisor("chapter-advisor")
+        self.math_student.advisor = advisor
+        self.math_student.save(update_fields=["advisor"])
+        self.client.force_login(advisor_user)
+
+        response = self.client.get(
+            "/get-chapters/",
+            {
+                "student_id": self.math_student.pk,
+                "lesson_id": self.math_eleventh.pk,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertEqual(
+            response.json(),
+            [
+                {
+                    "id": self.math_eleventh_chapter.pk,
+                    "text": "1 - فصل ریاضی یازدهم",
+                }
+            ],
+        )
+
+    def test_unassigned_advisor_cannot_load_student_chapters(self):
+        assigned_user, assigned_advisor = self.make_advisor("assigned-advisor")
+        other_user, _other_advisor = self.make_advisor("other-advisor")
+        self.math_student.advisor = assigned_advisor
+        self.math_student.save(update_fields=["advisor"])
+        self.client.force_login(other_user)
+
+        response = self.client.get(
+            "/get-chapters/",
+            {
+                "student_id": self.math_student.pk,
+                "lesson_id": self.math_eleventh.pk,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"], "دسترسی به این دانش‌آموز مجاز نیست.")
+
+    def test_chapter_endpoint_rejects_other_major_and_future_grade_lessons(self):
+        for lesson in (self.experimental_eleventh, self.math_twelfth):
+            response = self.client.get(
+                "/get-chapters/",
+                {
+                    "student_id": self.math_student.pk,
+                    "lesson_id": lesson.pk,
+                },
+            )
+            self.assertEqual(response.status_code, 403, response.content)

--- a/plans/test_plan_secondary.py
+++ b/plans/test_plan_secondary.py
@@ -26,6 +26,8 @@ class PlanSecondaryScriptTests(TestCase):
         geometry_style = b'/static/plans/plan-task-geometry.css?v='
         modern_style = b'/static/plans/plan-modern-ui.css?v='
         modern_fixes_style = b'/static/plans/plan-modern-ui-fixes.css?v='
+        start_style = b'/static/plans/plan-start-state.css?v='
+        quarter_style = b'/static/plans/plan-quarter-snap-feedback.css?v='
         runtime = b'/static/plans/plan-runtime.js?v='
         secondary = b'/static/plans/plan-secondary.js?v='
         grid = b'/static/plans/plan-time-grid.js?v='
@@ -35,6 +37,9 @@ class PlanSecondaryScriptTests(TestCase):
         lesson_toolbar = b'/static/plans/plan-lesson-toolbar.js?v='
         task_geometry = b'/static/plans/plan-task-geometry.js?v='
         modern_ui = b'/static/plans/plan-modern-ui.js?v='
+        start_state = b'/static/plans/plan-start-state.js?v='
+        chapter_loader = b'/static/plans/plan-chapter-loader.js?v='
+        quarter_feedback = b'/static/plans/plan-quarter-snap-feedback.js?v='
 
         markers = (
             interaction_style,
@@ -42,6 +47,8 @@ class PlanSecondaryScriptTests(TestCase):
             geometry_style,
             modern_style,
             modern_fixes_style,
+            start_style,
+            quarter_style,
             runtime,
             secondary,
             grid,
@@ -51,23 +58,35 @@ class PlanSecondaryScriptTests(TestCase):
             lesson_toolbar,
             task_geometry,
             modern_ui,
+            start_state,
+            chapter_loader,
+            quarter_feedback,
         )
         for marker in markers:
             self.assertEqual(content.count(marker), 1)
 
         for earlier, later in zip(markers, markers[1:]):
             self.assertLess(content.index(earlier), content.index(later))
-        self.assertLess(content.index(modern_ui), content.rfind(b"</body>"))
+        self.assertLess(content.index(quarter_feedback), content.rfind(b"</body>"))
 
-        self.assertIn(b'data-plan-interactions="true"', content)
-        self.assertIn(b'data-plan-manual-resize="true"', content)
-        self.assertIn(b'data-plan-drag-surface="true"', content)
-        self.assertIn(b'data-plan-time-grid="true"', content)
-        self.assertIn(b'data-plan-lesson-toolbar="true"', content)
-        self.assertIn(b'data-plan-task-geometry="true"', content)
-        self.assertIn(b'data-plan-modern-ui="true"', content)
-        self.assertIn(b'data-plan-interactions-style="true"', content)
-        self.assertIn(b'data-plan-time-grid-style="true"', content)
-        self.assertIn(b'data-plan-task-geometry-style="true"', content)
-        self.assertIn(b'data-plan-modern-ui-style="true"', content)
-        self.assertIn(b'data-plan-modern-ui-fixes-style="true"', content)
+        attributes = (
+            b'data-plan-interactions="true"',
+            b'data-plan-manual-resize="true"',
+            b'data-plan-drag-surface="true"',
+            b'data-plan-time-grid="true"',
+            b'data-plan-lesson-toolbar="true"',
+            b'data-plan-task-geometry="true"',
+            b'data-plan-modern-ui="true"',
+            b'data-plan-start-state="true"',
+            b'data-plan-chapter-loader="true"',
+            b'data-plan-quarter-snap-feedback="true"',
+            b'data-plan-interactions-style="true"',
+            b'data-plan-time-grid-style="true"',
+            b'data-plan-task-geometry-style="true"',
+            b'data-plan-modern-ui-style="true"',
+            b'data-plan-modern-ui-fixes-style="true"',
+            b'data-plan-start-state-style="true"',
+            b'data-plan-quarter-snap-feedback-style="true"',
+        )
+        for attribute in attributes:
+            self.assertIn(attribute, content)

--- a/plans/urls.py
+++ b/plans/urls.py
@@ -1,7 +1,14 @@
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from . import dashboard_admin, dashboard_page, lesson_catalog, plan_page, weekly_plans_v2
+from . import (
+    chapter_catalog,
+    dashboard_admin,
+    dashboard_page,
+    lesson_catalog,
+    plan_page,
+    weekly_plans_v2,
+)
 from .views import *
 
 
@@ -12,7 +19,7 @@ router.register(r"sessions", SessionViewSet, basename="session")
 urlpatterns = [
     path("plan/", plan_page.plan_view, name="plan"),
     path("move-lesson-to-end/", lesson_catalog.move_lesson_to_end, name="move_lesson_to_end"),
-    path("get-chapters/", get_chapters, name="get-chapters"),
+    path("get-chapters/", chapter_catalog.get_chapters, name="get-chapters"),
     path("save-weekly-report/", weekly_plans_v2.save_weekly_report, name="save_weekly_report"),
     path("get-weekly-report-details/", weekly_plans_v2.get_weekly_report_details, name="get_weekly_report_details"),
     path("update-lesson-order/", update_lesson_order, name="update_lesson_order"),


### PR DESCRIPTION
## گزارش مشاور
- فصل‌های کتاب بعد از انداختن درس داخل Plan لود نمی‌شدند.
- حرکت باکس‌ها مثل نسخه قبلی حس پله‌ای واضح ۱۵ دقیقه‌ای نداشت.

## علت فصل‌ها
فرانت `grade` و `major_code` را از state مرورگر برای `/get-chapters/` می‌فرستاد. بعد از تغییر دانش‌آموز، این مقادیر می‌توانستند stale باشند و API بدون خطای واضح لیست خالی برگرداند.

### اصلاح فصل‌ها
- Endpoint جدید و احراز هویت‌شده با ورودی فقط `student_id + lesson_id`
- استخراج پایه و رشته از دیتابیس، نه از مرورگر
- کنترل اینکه دانش‌آموز واقعاً متعلق به مشاور جاری باشد
- کنترل اینکه درس برای پایه و رشته دانش‌آموز مجاز باشد
- حذف فصل‌های تکراری و پشتیبانی از جست‌وجو
- بازسازی Select2 فصل برای باکس‌های جدید و ذخیره‌شده
- پیام واضح در صورت خطای بارگذاری به‌جای Dropdown خالی

## اصلاح حرکت ۱۵ دقیقه‌ای
- قفل واقعی Drag عمودی روی گام `8.75px = 15 دقیقه`
- نمایش زنده ساعت شروع و پایان هنگام حرکت
- نمایش خط مقصد دقیق روی ستون روز
- تفکیک بصری خطوط ۱۵ دقیقه، نیم‌ساعت و یک ساعت
- بدون تغییر فرمت ذخیره، Geometry یا قواعد overlap

## تست‌ها
- Advisor تخصیص‌یافته فصل‌ها را بدون ارسال grade/major دریافت می‌کند
- Advisor دیگر 403 می‌گیرد
- درس رشته دیگر یا پایه آینده رد می‌شود
- ترتیب Assetها و Syntax بررسی می‌شود
- Playwright Production:
  - Dropdown فصل واقعاً گزینه دریافت کند
  - درخواست فصل خطای 4xx/5xx نداشته باشد
  - Draggable دقیقاً گام ۱۵ دقیقه داشته باشد
  - Badge و خط مقصد هنگام Drag واقعی دیده شوند
  - پایان حرکت روی مرز گرید ۱۵ دقیقه باشد