### PR TITLE
Fix advisor assignment access for dashboard students

### DIFF
--- a/.github/workflows/validate-dashboard.yml
+++ b/.github/workflows/validate-dashboard.yml
@@ -5,8 +5,11 @@ on:
     paths:
       - 'accounts/**'
       - 'management/**'
+      - 'plans/advisor_access.py'
       - 'plans/dashboard_admin.py'
+      - 'plans/dashboard_assignment.py'
       - 'plans/dashboard_page.py'
+      - 'plans/management/commands/repair_student_advisor_assignments.py'
       - 'plans/static/plans/dashboard-responsive.css'
       - 'plans/test_dashboard_page.py'
       - 'plans/views.py'
@@ -14,6 +17,7 @@ on:
       - 'plans/templates/plans/management.html'
       - 'config/settings.py'
       - 'config/test_settings.py'
+      - 'deploy/deploy.sh'
       - 'deploy/dashboard_e2e.py'
       - 'deploy/dashboard_e2e_runner.py'
       - '.github/workflows/validate-dashboard.yml'
@@ -37,8 +41,12 @@ jobs:
           python3 -m py_compile \
             management/dashboard_security.py \
             management/test_dashboard.py \
+            management/test_assignment_access.py \
+            plans/advisor_access.py \
             plans/dashboard_admin.py \
+            plans/dashboard_assignment.py \
             plans/dashboard_page.py \
+            plans/management/commands/repair_student_advisor_assignments.py \
             plans/test_dashboard_page.py \
             deploy/dashboard_e2e.py \
             deploy/dashboard_e2e_runner.py
@@ -61,6 +69,7 @@ jobs:
           set +e
           .venv/bin/python manage.py test \
             management.test_dashboard \
+            management.test_assignment_access \
             plans.test_dashboard_page \
             --verbosity 2 > dashboard-test-output.txt 2>&1
           status=$?

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -145,6 +145,7 @@ cd "$APP_DIR"
 
 "$APP_DIR/venv/bin/python" manage.py check
 "$APP_DIR/venv/bin/python" manage.py migrate --noinput
+"$APP_DIR/venv/bin/python" manage.py repair_student_advisor_assignments
 "$APP_DIR/venv/bin/python" manage.py collectstatic --noinput
 
 chown -R www-data:www-data "$APP_DIR/media" "$APP_DIR/staticfiles"

--- a/management/dashboard_security.py
+++ b/management/dashboard_security.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from django.contrib.auth.models import User
 from rest_framework import status
-from rest_framework.response import Response
 
 from accounts.models import Advisor, Student
 from management.views import ConversationListView, MessageListView
+from plans.advisor_access import assigned_students_for_advisor, effective_advisor_id
 
 
 def _is_admin(user) -> bool:
@@ -27,9 +27,15 @@ def _allowed_direct_user_ids(user) -> set[int]:
     role = getattr(profile, "role", None)
 
     if role == "student":
+        student = Student.objects.filter(profile=profile).first()
+        if not student:
+            return set()
+        advisor_id = effective_advisor_id(student)
+        if not advisor_id:
+            return set()
         advisor_user_id = (
-            Student.objects.filter(profile=profile)
-            .values_list("advisor__profile__user_id", flat=True)
+            Advisor.objects.filter(pk=advisor_id)
+            .values_list("profile__user_id", flat=True)
             .first()
         )
         return {advisor_user_id} if advisor_user_id else set()
@@ -39,7 +45,7 @@ def _allowed_direct_user_ids(user) -> set[int]:
         if not advisor:
             return set()
         return set(
-            Student.objects.filter(advisor=advisor)
+            assigned_students_for_advisor(advisor)
             .exclude(profile__user_id__isnull=True)
             .values_list("profile__user_id", flat=True)
         )
@@ -48,7 +54,7 @@ def _allowed_direct_user_ids(user) -> set[int]:
 
 
 class SecuredConversationListView(ConversationListView):
-    """Keep conversation discovery aligned with role relationships."""
+    """Keep conversation discovery aligned with current advisor assignments."""
 
     def get(self, request):
         response = super().get(request)

--- a/management/test_assignment_access.py
+++ b/management/test_assignment_access.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from datetime import date, time
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.test import TestCase
+
+from accounts.models import Advisor, AdvisorAvailability, Grade, Major, Profile, School, Student
+from plans.models import Course
+
+
+class DashboardAssignmentAccessTests(TestCase):
+    def setUp(self):
+        self.grade = Grade.objects.create(name="یازدهم")
+        self.major = Major.objects.create(name="ریاضی")
+        self.school = School.objects.create(name="مدرسه تست تخصیص")
+
+        self.admin = self._make_user("assignment-admin", "admin", is_staff=True)
+        self.advisor_user = self._make_user("assignment-advisor", "advisor")
+        self.advisor = Advisor.objects.create(profile=self.advisor_user.profile)
+        self.other_advisor_user = self._make_user("assignment-other-advisor", "advisor")
+        self.other_advisor = Advisor.objects.create(profile=self.other_advisor_user.profile)
+        self.student_user = self._make_user("assignment-student", "student")
+        self.student = Student.objects.create(
+            profile=self.student_user.profile,
+            school=self.school,
+            major=self.major,
+            grade=self.grade,
+            advisor=None,
+        )
+
+        self.availability = AdvisorAvailability.objects.create(
+            advisor=self.advisor,
+            day_of_week="Monday",
+            start_time=time(10, 0),
+            end_time=time(11, 0),
+            max_students=5,
+        )
+
+    def _make_user(self, username: str, role: str, *, is_staff: bool = False) -> User:
+        user = User.objects.create_user(
+            username=username,
+            password="test-password",
+            is_staff=is_staff,
+        )
+        Profile.objects.create(
+            user=user,
+            role=role,
+            first_name=username,
+            last_name="تست",
+            phone_number=f"09{user.pk:09d}"[-11:],
+        )
+        return user
+
+    def _assign(self):
+        self.client.force_login(self.admin)
+        return self.client.post(
+            "/api/assign-student/",
+            data=json.dumps(
+                {
+                    "student_id": self.student.pk,
+                    "advisor_id": self.advisor.pk,
+                    "day_of_week": "Monday",
+                    "start_time": "10:00",
+                    "start_date": "2026-08-10",
+                }
+            ),
+            content_type="application/json",
+        )
+
+    def test_dashboard_assignment_persists_student_advisor_and_grants_chat(self):
+        response = self._assign()
+        self.assertEqual(response.status_code, 201, response.content)
+
+        self.student.refresh_from_db()
+        self.assertEqual(self.student.advisor_id, self.advisor.pk)
+        course = Course.objects.get(student=self.student, advisor=self.advisor)
+        self.assertEqual(course.sessions.count(), 4)
+
+        self.client.force_login(self.advisor_user)
+        advisor_chat = self.client.get(
+            f"/api/chat/messages/user:{self.student_user.pk}/"
+        )
+        self.assertEqual(advisor_chat.status_code, 200, advisor_chat.content)
+
+        self.client.force_login(self.student_user)
+        student_chat = self.client.get(
+            f"/api/chat/messages/user:{self.advisor_user.pk}/"
+        )
+        self.assertEqual(student_chat.status_code, 200, student_chat.content)
+
+        denied = self.client.get(
+            f"/api/chat/messages/user:{self.other_advisor_user.pk}/"
+        )
+        self.assertEqual(denied.status_code, 403)
+
+    def test_legacy_course_assignment_is_allowed_before_repair(self):
+        Course.objects.create(
+            student=self.student,
+            advisor=self.advisor,
+            day_of_week="Monday",
+            start_time=time(10, 0),
+            start_date=date(2026, 8, 10),
+            is_active=True,
+        )
+        self.assertIsNone(self.student.advisor_id)
+
+        self.client.force_login(self.advisor_user)
+        response = self.client.get(
+            f"/api/chat/messages/user:{self.student_user.pk}/"
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+        self.client.force_login(self.student_user)
+        response = self.client.get(
+            f"/api/chat/messages/user:{self.advisor_user.pk}/"
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+
+    def test_repair_command_backfills_latest_active_course_advisor(self):
+        Course.objects.create(
+            student=self.student,
+            advisor=self.other_advisor,
+            day_of_week="Tuesday",
+            start_time=time(9, 0),
+            start_date=date(2026, 7, 1),
+            is_active=True,
+        )
+        Course.objects.create(
+            student=self.student,
+            advisor=self.advisor,
+            day_of_week="Monday",
+            start_time=time(10, 0),
+            start_date=date(2026, 8, 10),
+            is_active=True,
+        )
+
+        call_command("repair_student_advisor_assignments")
+        self.student.refresh_from_db()
+        self.assertEqual(self.student.advisor_id, self.advisor.pk)
+
+        self.client.force_login(self.other_advisor_user)
+        denied = self.client.get(
+            f"/api/chat/messages/user:{self.student_user.pk}/"
+        )
+        self.assertEqual(denied.status_code, 403)
+
+        self.client.force_login(self.advisor_user)
+        allowed = self.client.get(
+            f"/api/chat/messages/user:{self.student_user.pk}/"
+        )
+        self.assertEqual(allowed.status_code, 200, allowed.content)

--- a/plans/advisor_access.py
+++ b/plans/advisor_access.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from django.db.models import Q, QuerySet
+
+from accounts.models import Advisor, Student
+from plans.models import Course
+
+
+def latest_active_course_advisor_id(student_id: int) -> int | None:
+    """Return the advisor from the most recently created active course."""
+
+    return (
+        Course.objects.filter(student_id=student_id, is_active=True)
+        .order_by("-created_at", "-pk")
+        .values_list("advisor_id", flat=True)
+        .first()
+    )
+
+
+def effective_advisor_id(student: Student) -> int | None:
+    """Resolve the student's current advisor.
+
+    `Student.advisor` is the canonical relationship. Older dashboard versions only
+    created a Course when assigning a student and left this FK empty. For those
+    legacy records we temporarily fall back to the newest active course so access
+    works immediately even before the repair command has run.
+    """
+
+    if student.advisor_id:
+        return student.advisor_id
+    return latest_active_course_advisor_id(student.pk)
+
+
+def student_is_assigned_to_advisor(student: Student, advisor: Advisor) -> bool:
+    return effective_advisor_id(student) == advisor.pk
+
+
+def assigned_students_for_advisor(advisor: Advisor) -> QuerySet[Student]:
+    """Students currently belonging to an advisor, including legacy assignments.
+
+    A Course fallback is used only when the Student.advisor FK is null. This keeps
+    a historical course from granting an old advisor access after a later explicit
+    reassignment changed Student.advisor.
+    """
+
+    legacy_student_ids = Course.objects.filter(
+        advisor=advisor,
+        is_active=True,
+        student__advisor__isnull=True,
+    ).values_list("student_id", flat=True)
+
+    return Student.objects.filter(
+        Q(advisor=advisor)
+        | Q(advisor__isnull=True, pk__in=legacy_student_ids)
+    ).distinct()
+
+
+def set_current_advisor(student: Student, advisor: Advisor) -> bool:
+    """Persist the canonical student -> advisor relationship."""
+
+    if student.advisor_id == advisor.pk:
+        return False
+    Student.objects.filter(pk=student.pk).update(advisor_id=advisor.pk)
+    student.advisor_id = advisor.pk
+    student.advisor = advisor
+    return True

--- a/plans/dashboard_assignment.py
+++ b/plans/dashboard_assignment.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import datetime
+import json
+
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.http import HttpResponseBadRequest, JsonResponse
+from django.views.decorators.http import require_POST
+
+from accounts.models import Advisor, AdvisorAvailability, Student
+from plans.advisor_access import set_current_advisor
+from plans.models import Course, Session
+
+
+@require_POST
+@login_required
+@transaction.atomic
+def assign_student_view(request):
+    """Assign a student to an advisor and create the four-session course.
+
+    The dashboard historically created only a Course and forgot to persist the
+    Student.advisor FK. Access-control code uses that FK, so the UI could report a
+    successful assignment while chat/Plan access still returned 403. The FK is now
+    updated in the same database transaction as the course and sessions.
+    """
+
+    if not request.user.is_staff:
+        return JsonResponse({"error": "Permission denied"}, status=403)
+
+    try:
+        data = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return HttpResponseBadRequest("Invalid JSON.")
+
+    required = ("student_id", "advisor_id", "day_of_week", "start_time", "start_date")
+    if any(data.get(field) in (None, "") for field in required):
+        return JsonResponse(
+            {"status": "error", "message": "اطلاعات تخصیص کامل نیست."},
+            status=400,
+        )
+
+    try:
+        student = Student.objects.select_for_update().get(pk=data["student_id"])
+        advisor = Advisor.objects.get(pk=data["advisor_id"])
+        start_date = datetime.datetime.strptime(
+            str(data["start_date"]), "%Y-%m-%d"
+        ).date()
+        start_time = datetime.datetime.strptime(
+            str(data["start_time"]), "%H:%M"
+        ).time()
+    except Student.DoesNotExist:
+        return JsonResponse(
+            {"status": "error", "message": "دانش‌آموز مورد نظر یافت نشد."},
+            status=404,
+        )
+    except Advisor.DoesNotExist:
+        return JsonResponse(
+            {"status": "error", "message": "مشاور مورد نظر یافت نشد."},
+            status=404,
+        )
+    except (TypeError, ValueError):
+        return JsonResponse(
+            {"status": "error", "message": "تاریخ یا ساعت تخصیص معتبر نیست."},
+            status=400,
+        )
+
+    day_of_week = str(data["day_of_week"]).strip()
+    availability = AdvisorAvailability.objects.filter(
+        advisor=advisor,
+        day_of_week=day_of_week,
+        start_time=start_time,
+    ).first()
+    if not availability:
+        return JsonResponse(
+            {
+                "status": "error",
+                "message": "برای مشاور انتخاب‌شده در این روز ساعت فعالی ثبت نشده است.",
+            },
+            status=400,
+        )
+
+    existing_assignments = Course.objects.filter(
+        advisor=advisor,
+        day_of_week=day_of_week,
+        start_time=start_time,
+        is_active=True,
+    ).count()
+    if existing_assignments >= availability.max_students:
+        return JsonResponse(
+            {
+                "status": "error",
+                "message": "ظرفیت این بازه زمانی برای مشاور انتخاب‌شده تکمیل است.",
+            },
+            status=400,
+        )
+
+    # This is the relationship used by chat, Plan visibility and other access
+    # checks. Keep it in the exact same transaction as the course creation.
+    set_current_advisor(student, advisor)
+
+    course = Course.objects.create(
+        student=student,
+        advisor=advisor,
+        day_of_week=day_of_week,
+        start_time=start_time,
+        start_date=start_date,
+    )
+
+    Session.objects.bulk_create(
+        [
+            Session(
+                course=course,
+                session_number=number,
+                date=start_date + datetime.timedelta(days=7 * (number - 1)),
+            )
+            for number in range(1, 5)
+        ]
+    )
+
+    return JsonResponse(
+        {
+            "status": "success",
+            "message": "دانش‌آموز با موفقیت تخصیص داده شد.",
+            "student_id": student.pk,
+            "advisor_id": advisor.pk,
+            "course_id": course.pk,
+        },
+        status=201,
+    )

--- a/plans/management/commands/repair_student_advisor_assignments.py
+++ b/plans/management/commands/repair_student_advisor_assignments.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from accounts.models import Student
+from plans.models import Course
+
+
+class Command(BaseCommand):
+    help = (
+        "Repair Student.advisor for legacy dashboard assignments that created a "
+        "Course but did not persist the student's advisor foreign key."
+    )
+
+    def handle(self, *args, **options):
+        repaired = 0
+        unchanged = 0
+        without_active_course = 0
+
+        students = Student.objects.select_related("profile", "advisor").order_by("pk")
+        for student in students.iterator():
+            advisor_id = (
+                Course.objects.filter(student_id=student.pk, is_active=True)
+                .order_by("-created_at", "-pk")
+                .values_list("advisor_id", flat=True)
+                .first()
+            )
+            if not advisor_id:
+                without_active_course += 1
+                continue
+
+            if student.advisor_id == advisor_id:
+                unchanged += 1
+                continue
+
+            old_id = student.advisor_id
+            Student.objects.filter(pk=student.pk).update(advisor_id=advisor_id)
+            repaired += 1
+            name = student.profile.get_full_name() if student.profile_id else str(student.pk)
+            self.stdout.write(
+                f"Repaired student {student.pk} ({name}): advisor {old_id} -> {advisor_id}"
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Advisor assignment repair complete: "
+                f"{repaired} repaired, {unchanged} already correct, "
+                f"{without_active_course} without active course."
+            )
+        )

--- a/plans/urls.py
+++ b/plans/urls.py
@@ -4,6 +4,7 @@ from rest_framework.routers import DefaultRouter
 from . import (
     chapter_catalog,
     dashboard_admin,
+    dashboard_assignment,
     dashboard_page,
     lesson_catalog,
     plan_page,
@@ -35,7 +36,7 @@ urlpatterns = [
     path("api/admin/advisors/", dashboard_admin.admin_advisors_view, name="api_admin_advisors"),
     path("api/admin/advisors/<int:advisor_id>/availability/", admin_advisor_add_availability, name="api_admin_advisor_add_availability"),
     path("api/admin/advisors/availability/<int:availability_id>/", admin_advisor_delete_availability, name="api_admin_advisor_delete_availability"),
-    path("api/assign-student/", assign_student_view, name="api_assign_student"),
+    path("api/assign-student/", dashboard_assignment.assign_student_view, name="api_assign_student"),
     path("api/log-weekly-report-action/", log_weekly_report_action, name="api_log_weekly_report_action"),
     path("", include(router.urls)),
 ]


### PR DESCRIPTION
## مشکل
Dashboard هنگام Assign دانش‌آموز فقط `Course` ایجاد می‌کرد و `Student.advisor` را تغییر نمی‌داد. در مقابل، چت و چند کنترل دسترسی از `Student.advisor` استفاده می‌کنند؛ بنابراین Assign در UI موفق دیده می‌شد ولی مشاور/دانش‌آموز 403 می‌گرفتند.

## اصلاح
- Endpoint تخصیص حالا `Student.advisor` و Course + چهار Session را در یک transaction ثبت می‌کند.
- چت برای داده‌های Legacy که Course دارند ولی `Student.advisor` هنوز null است، تا زمان Repair از جدیدترین Course فعال fallback می‌گیرد.
- fallback فقط وقتی FK خالی است؛ بنابراین یک Course تاریخی به مشاور قبلی دسترسی اضافه نمی‌دهد اگر دانش‌آموز رسماً به مشاور جدید منتقل شده باشد.
- Command جدید `repair_student_advisor_assignments` کل داده قبلی را از روی جدیدترین Course فعال backfill می‌کند.
- Deploy این Repair را خودکار بعد از migrate اجرا می‌کند؛ بنابراین Assignهای قبلی Production نیز اصلاح می‌شوند.

## Regression
- Assign جدید باید FK مشاور را ذخیره کند.
- بعد از Assign، چت دانش‌آموز و مشاور در هر دو جهت باید 200 باشد.
- مشاور غیرمرتبط باید 403 بگیرد.
- رکورد Legacy با `advisor=NULL` ولی Course فعال باید قبل از Repair هم مجاز باشد.
- Repair باید جدیدترین مشاور فعال را ثبت کند و دسترسی مشاور قبلی را ببندد.