### PR TITLE
Use one advisor access policy across Dashboard Chat and Plan

### DIFF
--- a/management/test_assignment_access.py
+++ b/management/test_assignment_access.py
@@ -70,7 +70,35 @@ class DashboardAssignmentAccessTests(TestCase):
             content_type="application/json",
         )
 
-    def test_dashboard_assignment_persists_student_advisor_and_grants_chat(self):
+    def _assert_advisor_can_use_student_across_surfaces(self):
+        self.client.force_login(self.advisor_user)
+
+        chat = self.client.get(f"/api/chat/messages/user:{self.student_user.pk}/")
+        self.assertEqual(chat.status_code, 200, chat.content)
+
+        plan_page = self.client.get("/plan/")
+        self.assertEqual(plan_page.status_code, 200, plan_page.content)
+        student_ids = {student.pk for student in plan_page.context["students"]}
+        self.assertIn(self.student.pk, student_ids)
+
+        lessons = self.client.get(
+            "/get-lessons-for-student/", {"student_id": self.student.pk}
+        )
+        self.assertEqual(lessons.status_code, 200, lessons.content)
+
+        check = self.client.get(
+            "/check-weekly-report/",
+            {"student_id": self.student.pk, "selected_date": "2026-08-10"},
+        )
+        self.assertEqual(check.status_code, 200, check.content)
+
+        report = self.client.get(
+            "/get-weekly-report-details/",
+            {"student_id": self.student.pk, "week_start": "2026-08-10"},
+        )
+        self.assertEqual(report.status_code, 200, report.content)
+
+    def test_dashboard_assignment_persists_student_advisor_and_grants_every_surface(self):
         response = self._assign()
         self.assertEqual(response.status_code, 201, response.content)
 
@@ -79,11 +107,7 @@ class DashboardAssignmentAccessTests(TestCase):
         course = Course.objects.get(student=self.student, advisor=self.advisor)
         self.assertEqual(course.sessions.count(), 4)
 
-        self.client.force_login(self.advisor_user)
-        advisor_chat = self.client.get(
-            f"/api/chat/messages/user:{self.student_user.pk}/"
-        )
-        self.assertEqual(advisor_chat.status_code, 200, advisor_chat.content)
+        self._assert_advisor_can_use_student_across_surfaces()
 
         self.client.force_login(self.student_user)
         student_chat = self.client.get(
@@ -96,7 +120,7 @@ class DashboardAssignmentAccessTests(TestCase):
         )
         self.assertEqual(denied.status_code, 403)
 
-    def test_legacy_course_assignment_is_allowed_before_repair(self):
+    def test_legacy_course_assignment_is_allowed_across_plan_and_chat_before_repair(self):
         Course.objects.create(
             student=self.student,
             advisor=self.advisor,
@@ -107,17 +131,36 @@ class DashboardAssignmentAccessTests(TestCase):
         )
         self.assertIsNone(self.student.advisor_id)
 
-        self.client.force_login(self.advisor_user)
-        response = self.client.get(
-            f"/api/chat/messages/user:{self.student_user.pk}/"
-        )
-        self.assertEqual(response.status_code, 200, response.content)
+        self._assert_advisor_can_use_student_across_surfaces()
 
         self.client.force_login(self.student_user)
         response = self.client.get(
             f"/api/chat/messages/user:{self.advisor_user.pk}/"
         )
         self.assertEqual(response.status_code, 200, response.content)
+
+    def test_unrelated_advisor_is_denied_across_plan_and_chat(self):
+        response = self._assign()
+        self.assertEqual(response.status_code, 201, response.content)
+        self.client.force_login(self.other_advisor_user)
+
+        self.assertEqual(
+            self.client.get(f"/api/chat/messages/user:{self.student_user.pk}/").status_code,
+            403,
+        )
+        self.assertEqual(
+            self.client.get(
+                "/get-lessons-for-student/", {"student_id": self.student.pk}
+            ).status_code,
+            403,
+        )
+        self.assertEqual(
+            self.client.get(
+                "/check-weekly-report/",
+                {"student_id": self.student.pk, "selected_date": "2026-08-10"},
+            ).status_code,
+            403,
+        )
 
     def test_repair_command_backfills_latest_active_course_advisor(self):
         Course.objects.create(

--- a/plans/advisor_access.py
+++ b/plans/advisor_access.py
@@ -20,10 +20,9 @@ def latest_active_course_advisor_id(student_id: int) -> int | None:
 def effective_advisor_id(student: Student) -> int | None:
     """Resolve the student's current advisor.
 
-    `Student.advisor` is the canonical relationship. Older dashboard versions only
-    created a Course when assigning a student and left this FK empty. For those
-    legacy records we temporarily fall back to the newest active course so access
-    works immediately even before the repair command has run.
+    `Student.advisor` is canonical. Older dashboard versions created only a
+    Course, so records with a null FK temporarily fall back to the newest active
+    course until the deployment repair has backfilled them.
     """
 
     if student.advisor_id:
@@ -36,12 +35,7 @@ def student_is_assigned_to_advisor(student: Student, advisor: Advisor) -> bool:
 
 
 def assigned_students_for_advisor(advisor: Advisor) -> QuerySet[Student]:
-    """Students currently belonging to an advisor, including legacy assignments.
-
-    A Course fallback is used only when the Student.advisor FK is null. This keeps
-    a historical course from granting an old advisor access after a later explicit
-    reassignment changed Student.advisor.
-    """
+    """Students currently belonging to an advisor, including legacy assignments."""
 
     legacy_student_ids = Course.objects.filter(
         advisor=advisor,
@@ -53,6 +47,25 @@ def assigned_students_for_advisor(advisor: Advisor) -> QuerySet[Student]:
         Q(advisor=advisor)
         | Q(advisor__isnull=True, pk__in=legacy_student_ids)
     ).distinct()
+
+
+def user_can_access_student(user, student: Student) -> bool:
+    """Single access policy used by Dashboard, Chat and weekly Plan APIs."""
+
+    if not user or not user.is_authenticated:
+        return False
+    if user.is_staff:
+        return True
+
+    profile = getattr(user, "profile", None)
+    if not profile:
+        return False
+    if profile.role == "student":
+        return student.profile_id == profile.pk
+    if profile.role == "advisor":
+        advisor = Advisor.objects.filter(profile=profile).first()
+        return bool(advisor and student_is_assigned_to_advisor(student, advisor))
+    return False
 
 
 def set_current_advisor(student: Student, advisor: Advisor) -> bool:

--- a/plans/lesson_catalog.py
+++ b/plans/lesson_catalog.py
@@ -5,6 +5,7 @@ from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import render
 
 from accounts.models import Advisor, Grade, Profile, Student
+from plans.advisor_access import assigned_students_for_advisor, student_is_assigned_to_advisor
 from plans.default_plan_data import DEFAULT_BOXES
 from plans.models import Box, DefaultEvent, Lesson, WeeklyReportDetail
 
@@ -72,12 +73,7 @@ def canonical_grade_name(value: object) -> str | None:
 
 
 def allowed_grade_names(student: Student) -> set[str]:
-    """Return the student's current grade and all completed lower grades.
-
-    A tenth-grade student sees only tenth-grade lessons. An eleventh-grade
-    student sees tenth and eleventh grade. A twelfth-grade student sees all
-    three grades. Lessons from a future grade are never returned by the API.
-    """
+    """Return the student's current grade and all completed lower grades."""
 
     current = canonical_grade_name(student.grade.name)
     if current is None:
@@ -122,8 +118,14 @@ def _student_is_visible(request, student: Student) -> bool:
     if request.user.is_staff:
         return True
     profile = _request_profile(request)
-    advisor = Advisor.objects.filter(profile=profile).first() if profile else None
-    return bool(advisor and student.advisor_id == advisor.pk)
+    if not profile:
+        return False
+    if profile.role == "student":
+        return student.profile_id == profile.pk
+    if profile.role != "advisor":
+        return False
+    advisor = Advisor.objects.filter(profile=profile).first()
+    return bool(advisor and student_is_assigned_to_advisor(student, advisor))
 
 
 def sort_lessons_for_student(student: Student) -> dict[str, list[Lesson]]:
@@ -216,9 +218,7 @@ def plan_view(request):
     else:
         advisor = Advisor.objects.filter(profile=profile).first() if profile else None
         students = (
-            Student.objects.select_related("profile", "major", "grade").filter(
-                advisor=advisor
-            )
+            assigned_students_for_advisor(advisor).select_related("profile", "major", "grade")
             if advisor
             else Student.objects.none()
         )
@@ -258,7 +258,7 @@ def get_lessons_for_student(request):
         return HttpResponseBadRequest("Missing student_id parameter.")
 
     try:
-        student = Student.objects.select_related("major", "grade").get(pk=student_id)
+        student = Student.objects.select_related("profile", "advisor", "major", "grade").get(pk=student_id)
     except Student.DoesNotExist:
         return HttpResponseBadRequest("Student not found.")
 
@@ -327,7 +327,7 @@ def get_default_events(request):
         return JsonResponse({"error": "Missing student_id"}, status=400)
 
     try:
-        student = Student.objects.get(pk=student_id)
+        student = Student.objects.select_related("profile", "advisor").get(pk=student_id)
     except Student.DoesNotExist:
         return JsonResponse({"error": "Student not found"}, status=400)
 
@@ -392,7 +392,7 @@ def move_lesson_to_end(request):
 
     try:
         selected_id = int(lesson_id)
-        student = Student.objects.select_related("major", "grade").get(pk=student_id)
+        student = Student.objects.select_related("profile", "advisor", "major", "grade").get(pk=student_id)
     except (TypeError, ValueError, Student.DoesNotExist):
         return JsonResponse({"error": "Invalid lesson or student"}, status=400)
 

--- a/plans/urls.py
+++ b/plans/urls.py
@@ -8,9 +8,22 @@ from . import (
     dashboard_page,
     lesson_catalog,
     plan_page,
+    weekly_plans,
     weekly_plans_v2,
 )
+from .advisor_access import user_can_access_student
 from .views import *
+
+
+# weekly_plans_v2 imports _student_or_response from the legacy weekly_plans
+# module. Keep that validator, but make its access decision use the same policy
+# as Dashboard, Chat and the Plan lesson endpoints. This compatibility hook can
+# be removed once the legacy module is retired.
+def _canonical_weekly_student_access(request, student):
+    return user_can_access_student(request.user, student)
+
+
+weekly_plans._can_access_student = _canonical_weekly_student_access
 
 
 router = DefaultRouter()


### PR DESCRIPTION
The assignment bug exposed a second inconsistency: Chat, lesson endpoints and weekly-plan APIs were not all resolving advisor/student access the same way.

This change makes the advisor relationship authoritative everywhere:
- Plan student list uses the same assigned-student resolver as Dashboard/Chat.
- Lesson/default-event endpoints use the canonical relationship.
- Weekly report check/load/save/copy access uses the same policy through the legacy compatibility hook.
- Student users can still access only themselves.
- Unrelated advisors remain 403.
- Legacy records with Student.advisor null but an active Course remain usable until repaired.

Regression tests explicitly verify the same assigned student across Chat, `/plan/`, lesson loading, weekly report checking and report loading, plus denial for an unrelated advisor.