### PR TITLE
Make chapter headings readable inside Plan study boxes

### DIFF
--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -13,6 +13,7 @@ on:
       - 'deploy/plan_task_independence_e2e.py'
       - 'deploy/plan_responsive_ui_e2e.py'
       - 'deploy/plan_chapter_snap_e2e.py'
+      - 'deploy/plan_chapter_visibility_e2e.py'
       - 'config/test_settings.py'
       - '.github/workflows/deploy.yml'
       - '.github/workflows/validate-plan.yml'
@@ -53,6 +54,7 @@ jobs:
             deploy/plan_task_independence_e2e.py \
             deploy/plan_responsive_ui_e2e.py \
             deploy/plan_chapter_snap_e2e.py \
+            deploy/plan_chapter_visibility_e2e.py \
             plans/management/commands/cleanup_plan_demo_reports.py \
             plans/chapter_catalog.py \
             plans/lesson_catalog.py \

--- a/.github/workflows/verify-plan-interactions.yml
+++ b/.github/workflows/verify-plan-interactions.yml
@@ -73,6 +73,10 @@ jobs:
             > plan-chapter-snap-output.txt 2>&1
           chapter_snap_status=$?
 
+          .plan-real-browser-venv/bin/python deploy/plan_chapter_visibility_e2e.py \
+            > plan-chapter-visibility-output.txt 2>&1
+          chapter_visibility_status=$?
+
           echo '===== Core real interactions ====='
           cat plan-real-interaction-output.txt
           echo '===== School-block drag interactions ====='
@@ -85,9 +89,11 @@ jobs:
           cat plan-responsive-ui-output.txt
           echo '===== Chapter loading and quarter-hour feedback ====='
           cat plan-chapter-snap-output.txt
+          echo '===== Visible chapter headings ====='
+          cat plan-chapter-visibility-output.txt
 
           status=0
-          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ] || [ "$independence_status" -ne 0 ] || [ "$responsive_status" -ne 0 ] || [ "$chapter_snap_status" -ne 0 ]; then
+          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ] || [ "$independence_status" -ne 0 ] || [ "$responsive_status" -ne 0 ] || [ "$chapter_snap_status" -ne 0 ] || [ "$chapter_visibility_status" -ne 0 ]; then
             status=1
           fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
@@ -105,6 +111,7 @@ jobs:
             plan-task-independence-output.txt
             plan-responsive-ui-output.txt
             plan-chapter-snap-output.txt
+            plan-chapter-visibility-output.txt
           retention-days: 3
 
       - name: Publish real interaction status
@@ -120,10 +127,10 @@ jobs:
           set -euo pipefail
           if [ "${TEST_STATUS:-1}" = "0" ]; then
             STATE='success'
-            DESCRIPTION='Plan interactions, chapters, 15-minute snap and responsive UI passed.'
+            DESCRIPTION='Plan interactions, visible chapters, 15-minute snap and responsive UI passed.'
           else
             STATE='failure'
-            DESCRIPTION='Plan interaction, chapter loading, snap or responsive regression failed.'
+            DESCRIPTION='Plan interaction, chapter visibility, snap or responsive regression failed.'
           fi
 
           jq -n \

--- a/deploy/plan_chapter_visibility_e2e.py
+++ b/deploy/plan_chapter_visibility_e2e.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import os
+import sys
+from urllib.parse import urljoin
+
+from playwright.sync_api import Locator, Page, sync_playwright
+
+
+BASE_URL = os.environ.get(
+    "PLAN_BASE_URL", "https://panel.kimiagarkhoone.com"
+).rstrip("/") + "/"
+USERNAME = os.environ.get("PLAN_USERNAME", "").strip()
+PASSWORD = os.environ.get("PLAN_PASSWORD", "")
+TEST_WEEK = os.environ.get("PLAN_GRID_TEST_WEEK", "1405-09-01")
+STUDENT_LABEL = os.environ.get("PLAN_GRID_STUDENT_LABEL", "نمونه ریاضی یازدهم")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+    print(f"PASS: {message}")
+
+
+def box(locator: Locator) -> dict[str, float]:
+    value = locator.bounding_box()
+    if not value:
+        raise AssertionError("Element has no visible bounding box")
+    return value
+
+
+def load_week(page: Page) -> None:
+    page.select_option("#student-select", label=STUDENT_LABEL)
+    page.evaluate(
+        """
+        value => {
+          window.jQuery('#weekSelector')
+            .val(value)
+            .trigger('input')
+            .trigger('change');
+        }
+        """,
+        TEST_WEEK,
+    )
+    page.click("#loadWeek")
+    page.wait_for_function(
+        "window.planRuntimeState && window.planRuntimeState.loaded && "
+        "!window.planRuntimeState.loading",
+        timeout=30_000,
+    )
+    page.wait_for_function(
+        "window.planChapterLoader && "
+        "document.body.dataset.planChapterLoaderVersion",
+        timeout=20_000,
+    )
+
+
+def drag_palette_to(page: Page, source: Locator, target: Locator) -> None:
+    source.scroll_into_view_if_needed()
+    source_box = box(source)
+    target_box = box(target)
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2,
+        source_box["y"] + source_box["height"] / 2,
+    )
+    page.mouse.down()
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2 + 7,
+        source_box["y"] + source_box["height"] / 2 + 7,
+        steps=4,
+    )
+    page.mouse.move(
+        target_box["x"] + target_box["width"] / 2,
+        target_box["y"] + 230,
+        steps=28,
+    )
+    page.mouse.up()
+    page.wait_for_timeout(500)
+
+
+def main() -> int:
+    if not USERNAME or not PASSWORD:
+        print("PLAN_USERNAME and PLAN_PASSWORD are required.", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(locale="fa-IR", viewport={"width": 1440, "height": 950})
+        page = context.new_page()
+        page.on("pageerror", lambda error: errors.append(str(error)))
+        page.on("dialog", lambda dialog: dialog.accept())
+
+        page.goto(urljoin(BASE_URL, "login/"), wait_until="domcontentloaded", timeout=30_000)
+        page.fill("#username", USERNAME)
+        page.fill("#password", PASSWORD)
+        page.click('form button[type="submit"]')
+        page.wait_for_url("**/plan/", timeout=30_000)
+        page.wait_for_function("window.jQuery && window.jQuery.ui", timeout=20_000)
+        load_week(page)
+
+        containers = page.locator(".calendar .task-container")
+        target = None
+        for index in range(containers.count()):
+            candidate = containers.nth(index)
+            if candidate.locator(":scope > .calendar-task").count() == 0:
+                target = candidate
+                break
+        require(target is not None, "an empty calendar day is available")
+
+        palette = page.locator(".subjects-box .plan-lesson-palette:visible").first
+        require(palette.count() == 1, "a visible lesson is available")
+        lesson_id = palette.get_attribute("data-lesson-id")
+        require(bool(lesson_id), "lesson palette exposes lesson id")
+
+        drag_palette_to(page, palette, target)
+        task = target.locator(
+            f':scope > .calendar-task[data-lesson-id="{lesson_id}"]'
+        ).first
+        require(task.count() == 1, "lesson card is created")
+
+        page.wait_for_function(
+            """
+            element => Boolean(
+              element &&
+              element.querySelector('.task-chapter[data-plan-chapter-loader-version]')
+            )
+            """,
+            arg=task.element_handle(),
+            timeout=10_000,
+        )
+
+        chapter_select = task.locator(".task-chapter")
+        select2 = chapter_select.locator(
+            "xpath=following-sibling::*[contains(@class, 'select2-container')]"
+        ).first
+        require(select2.count() == 1, "chapter Select2 exists inside the lesson card")
+
+        rendered_before = select2.locator(".select2-selection__rendered").first
+        require(rendered_before.is_visible(), "chapter field itself is visible in the lesson card")
+        initial_style = rendered_before.evaluate(
+            """
+            element => {
+              const style = getComputedStyle(element);
+              return {
+                color: style.color,
+                opacity: Number.parseFloat(style.opacity || '1'),
+                fontSize: Number.parseFloat(style.fontSize || '0'),
+                text: String(element.textContent || '').trim()
+              };
+            }
+            """
+        )
+        require(initial_style["opacity"] >= 0.95, "chapter field text is not transparent")
+        require(initial_style["fontSize"] >= 9, "chapter field text has a readable font size")
+        require(bool(initial_style["text"]), "chapter field shows a visible placeholder or selection")
+
+        select2.click()
+        page.wait_for_selector(".select2-dropdown.plan-chapter-dropdown", state="visible", timeout=10_000)
+        page.wait_for_function(
+            """
+            () => Array.from(document.querySelectorAll('.plan-chapter-dropdown .select2-results__option'))
+              .some(option => {
+                const text = String(option.textContent || '').trim();
+                return text && !option.classList.contains('loading-results');
+              })
+            """,
+            timeout=10_000,
+        )
+
+        dropdown = page.locator(".select2-dropdown.plan-chapter-dropdown:visible").last
+        dropdown_box = box(dropdown)
+        require(dropdown_box["width"] >= 250, "chapter dropdown is wide enough to read real headings")
+        require(dropdown_box["x"] >= -1, "chapter dropdown stays inside the left viewport edge")
+        require(
+            dropdown_box["x"] + dropdown_box["width"] <= 1441,
+            "chapter dropdown stays inside the right viewport edge",
+        )
+
+        options = dropdown.locator(".select2-results__option")
+        visible_option = None
+        for index in range(options.count()):
+            candidate = options.nth(index)
+            text = candidate.inner_text().strip()
+            if text and "در حال" not in text:
+                visible_option = candidate
+                break
+        require(visible_option is not None, "at least one real chapter heading is rendered")
+        require(visible_option.is_visible(), "chapter heading is visibly rendered, not only present in DOM")
+
+        option_style = visible_option.evaluate(
+            """
+            element => {
+              const style = getComputedStyle(element);
+              const rect = element.getBoundingClientRect();
+              return {
+                color: style.color,
+                backgroundColor: style.backgroundColor,
+                opacity: Number.parseFloat(style.opacity || '1'),
+                visibility: style.visibility,
+                display: style.display,
+                fontSize: Number.parseFloat(style.fontSize || '0'),
+                lineHeight: Number.parseFloat(style.lineHeight || '0'),
+                width: rect.width,
+                height: rect.height,
+                text: String(element.textContent || '').trim()
+              };
+            }
+            """
+        )
+        require(option_style["display"] != "none", "chapter heading is not display:none")
+        require(option_style["visibility"] != "hidden", "chapter heading is not visibility:hidden")
+        require(option_style["opacity"] >= 0.95, "chapter heading is opaque")
+        require(option_style["fontSize"] >= 11, "chapter heading uses readable typography")
+        require(option_style["height"] >= 30, "chapter row has enough visible height")
+        require(len(option_style["text"]) >= 2, "chapter row contains visible heading text")
+
+        chosen_text = option_style["text"]
+        visible_option.click()
+        page.wait_for_timeout(250)
+
+        display_text = task.evaluate(
+            """
+            element => {
+              const compact = element.querySelector('.plan-chapter-chip');
+              if (compact && getComputedStyle(compact).display !== 'none') {
+                return String(compact.textContent || '').trim();
+              }
+              const rendered = element.querySelector('.select2-selection__rendered');
+              return rendered ? String(rendered.textContent || '').trim() : '';
+            }
+            """
+        )
+        require(bool(display_text), "selected chapter heading remains visible inside the lesson card")
+        require(
+            chosen_text in display_text or display_text in chosen_text,
+            "lesson card displays the chapter that was selected",
+        )
+        require(not errors, "chapter visibility flow has no uncaught JavaScript errors: " + " | ".join(errors))
+
+        context.close()
+        browser.close()
+
+    print("Plan chapter visibility regression completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260802-2"
+ASSET_VERSION = "20260807-1"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
     ("plans/plan-time-grid.css", "data-plan-time-grid-style"),

--- a/plans/static/plans/plan-chapter-loader.js
+++ b/plans/static/plans/plan-chapter-loader.js
@@ -5,7 +5,7 @@
     return;
   }
 
-  const VERSION = '2026.08.02.1';
+  const VERSION = '2026.08.07.1';
   let synchronizeQueued = false;
 
   function currentStudentId() {
@@ -16,13 +16,54 @@
   function markError($task, message) {
     $task
       .addClass('plan-chapter-load-error')
-      .attr('data-plan-chapter-error', String(message || 'بارگذاری فصل‌ها انجام نشد.'));
+      .attr('data-plan-chapter-error', String(message || 'بارگذاری سرفصل‌ها انجام نشد.'));
   }
 
   function clearError($task) {
     $task
       .removeClass('plan-chapter-load-error')
       .removeAttr('data-plan-chapter-error');
+  }
+
+  function chapterTemplate(item) {
+    if (!item || item.loading) {
+      return item && item.text ? item.text : '';
+    }
+    return $('<span class="plan-chapter-option-text"></span>').text(
+      String(item.text || '').trim()
+    );
+  }
+
+  function chapterSelection(item) {
+    const text = String((item && item.text) || '').trim();
+    return text || 'انتخاب سرفصل';
+  }
+
+  function keepDropdownInsideViewport() {
+    const $dropdown = $('.select2-dropdown.plan-chapter-dropdown:visible').last();
+    if (!$dropdown.length) {
+      return;
+    }
+
+    const viewportWidth = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
+    const comfortableWidth = Math.min(390, Math.max(260, viewportWidth - 24));
+    $dropdown.css({
+      width: comfortableWidth + 'px',
+      minWidth: comfortableWidth + 'px',
+      maxWidth: 'calc(100vw - 24px)'
+    });
+
+    const rect = $dropdown[0].getBoundingClientRect();
+    let delta = 0;
+    if (rect.left < 12) {
+      delta = 12 - rect.left;
+    } else if (rect.right > viewportWidth - 12) {
+      delta = (viewportWidth - 12) - rect.right;
+    }
+    if (delta) {
+      const currentLeft = Number.parseFloat($dropdown.css('left')) || 0;
+      $dropdown.css('left', currentLeft + delta + 'px');
+    }
   }
 
   function configureChapterSelect(task) {
@@ -53,15 +94,24 @@
     }
 
     $select.select2({
-      placeholder: 'شماره فصل',
-      dropdownParent: $task,
+      placeholder: 'انتخاب سرفصل',
+      // The calendar column is intentionally narrow. Rendering the dropdown
+      // inside the task made real chapter names look clipped/blank. Appending
+      // to body lets the result list use a readable width without changing the
+      // lesson card geometry.
+      dropdownParent: $('body'),
+      dropdownAutoWidth: true,
+      dropdownCssClass: 'plan-chapter-dropdown',
       width: '100%',
       theme: 'bootstrap-5',
       allowClear: true,
+      templateResult: chapterTemplate,
+      templateSelection: chapterSelection,
+      escapeMarkup: function (markup) { return markup; },
       language: {
-        errorLoading: function () { return 'بارگذاری فصل‌ها انجام نشد'; },
+        errorLoading: function () { return 'بارگذاری سرفصل‌ها انجام نشد'; },
         loadingMore: function () { return 'در حال بارگذاری…'; },
-        noResults: function () { return 'فصلی برای این درس پیدا نشد'; },
+        noResults: function () { return 'سرفصلی برای این درس پیدا نشد'; },
         searching: function () { return 'در حال جست‌وجو…'; }
       },
       ajax: {
@@ -83,7 +133,7 @@
           });
           request.fail(function (xhr) {
             const payload = xhr.responseJSON || {};
-            markError($task, payload.error || payload.message || 'بارگذاری فصل‌ها انجام نشد.');
+            markError($task, payload.error || payload.message || 'بارگذاری سرفصل‌ها انجام نشد.');
             failure(xhr);
           });
           return request;
@@ -97,6 +147,12 @@
     if (selectedValue) {
       $select.val(selectedValue).trigger('change.select2');
     }
+
+    $select
+      .off('.planChapterVisibility')
+      .on('select2:open.planChapterVisibility', function () {
+        window.requestAnimationFrame(keepDropdownInsideViewport);
+      });
 
     $select.attr('data-plan-chapter-loader-version', VERSION);
   }
@@ -164,6 +220,9 @@
       queueSynchronize();
     });
     window.addEventListener('plan:lesson-toolbar-updated', queueSynchronize);
+    window.addEventListener('resize', function () {
+      window.requestAnimationFrame(keepDropdownInsideViewport);
+    });
 
     window.planChapterLoader = {
       version: VERSION,

--- a/plans/static/plans/plan-interactions.css
+++ b/plans/static/plans/plan-interactions.css
@@ -127,7 +127,7 @@ body.plan-resize-cursor * {
   height: 28px !important;
   border: 1px solid rgba(100, 116, 139, 0.35) !important;
   border-radius: 8px !important;
-  background: rgba(255, 255, 255, 0.94) !important;
+  background: rgba(255, 255, 255, 0.98) !important;
   box-shadow: none !important;
 }
 
@@ -136,7 +136,19 @@ body.plan-resize-cursor * {
   line-height: 26px !important;
   padding-right: 7px !important;
   padding-left: 20px !important;
+  color: #0f172a !important;
   font-size: 10px !important;
+  font-weight: 700 !important;
+  opacity: 1 !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+.extended-task.plan-study-editing .select2-selection__placeholder,
+.extended-task.plan-study-editor-pinned .select2-selection__placeholder {
+  color: #64748b !important;
+  opacity: 1 !important;
 }
 
 .extended-task.plan-study-editing .select2-selection__arrow,
@@ -161,10 +173,11 @@ body.plan-resize-cursor * {
   height: 23px;
   padding: 0 7px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  color: #334155;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  color: #1e293b;
   font-size: 9px;
+  font-weight: 700;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -174,7 +187,7 @@ body.plan-resize-cursor * {
   flex: 0 0 auto;
   max-width: none;
   color: #0f766e;
-  background: rgba(204, 251, 241, 0.86);
+  background: rgba(204, 251, 241, 0.9);
 }
 
 .plan-study-edit {
@@ -218,6 +231,84 @@ body.plan-resize-cursor * {
   background: #2563eb !important;
 }
 
+/* Chapter dropdowns are appended to body so narrow calendar cards cannot clip them. */
+.select2-container--open {
+  z-index: 40000 !important;
+}
+
+.select2-dropdown.plan-chapter-dropdown {
+  direction: rtl !important;
+  overflow: hidden !important;
+  color: #0f172a !important;
+  border: 1px solid #cbd5e1 !important;
+  border-radius: 12px !important;
+  background: #ffffff !important;
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.22) !important;
+}
+
+.plan-chapter-dropdown .select2-search {
+  padding: 8px !important;
+  background: #f8fafc !important;
+  border-bottom: 1px solid #e2e8f0 !important;
+}
+
+.plan-chapter-dropdown .select2-search__field {
+  min-height: 32px !important;
+  padding: 5px 9px !important;
+  color: #0f172a !important;
+  font-size: 11px !important;
+  border: 1px solid #cbd5e1 !important;
+  border-radius: 8px !important;
+  background: #ffffff !important;
+}
+
+.plan-chapter-dropdown .select2-results {
+  background: #ffffff !important;
+}
+
+.plan-chapter-dropdown .select2-results__options {
+  max-height: 320px !important;
+  overflow-y: auto !important;
+  overscroll-behavior: contain;
+}
+
+.plan-chapter-dropdown .select2-results__option {
+  min-height: 38px !important;
+  padding: 9px 12px !important;
+  color: #0f172a !important;
+  font-size: 12px !important;
+  font-weight: 700 !important;
+  line-height: 1.75 !important;
+  text-align: right !important;
+  white-space: normal !important;
+  overflow-wrap: anywhere !important;
+  background: #ffffff !important;
+  border-bottom: 1px solid #f1f5f9;
+}
+
+.plan-chapter-dropdown .select2-results__option:last-child {
+  border-bottom: 0;
+}
+
+.plan-chapter-dropdown .select2-results__option--highlighted,
+.plan-chapter-dropdown .select2-results__option[aria-selected="true"].select2-results__option--highlighted {
+  color: #ffffff !important;
+  background: #2563eb !important;
+}
+
+.plan-chapter-dropdown .select2-results__option[aria-selected="true"]:not(.select2-results__option--highlighted) {
+  color: #1d4ed8 !important;
+  background: #eff6ff !important;
+}
+
+.plan-chapter-option-text {
+  display: block;
+  width: 100%;
+  color: inherit;
+  font: inherit;
+  line-height: inherit;
+}
+
 @media (max-width: 900px) {
   .plan-resize-handle {
     height: 20px !important;
@@ -226,5 +317,17 @@ body.plan-resize-cursor * {
 
   .plan-resize-handle span {
     width: 44px;
+  }
+}
+
+@media (max-width: 520px) {
+  .select2-dropdown.plan-chapter-dropdown {
+    width: calc(100vw - 24px) !important;
+    min-width: calc(100vw - 24px) !important;
+    max-width: calc(100vw - 24px) !important;
+  }
+
+  .plan-chapter-dropdown .select2-results__option {
+    font-size: 12px !important;
   }
 }


### PR DESCRIPTION
## مشکل
سرفصل‌ها از API می‌آمدند و داخل DOM هم وجود داشتند، اما Select2 داخل عرض خیلی باریک باکس درس باز می‌شد. در نتیجه متن واقعی سرفصل‌ها در UI فشرده/بریده و عملاً ناخوانا دیده می‌شد. تست قبلی فقط وجود optionها در DOM را چک می‌کرد و این ایراد بصری را نمی‌گرفت.

## اصلاح
- Dropdown سرفصل از خود lesson card به `body` منتقل شد تا توسط عرض باکس محدود نشود.
- عرض خوانای 260 تا 390px با کنترل لبه‌های viewport اضافه شد.
- متن سرفصل‌ها RTL، چندخطی، 12px، پرکنتراست و با ارتفاع مناسب نمایش داده می‌شود.
- Placeholder به «انتخاب سرفصل» تغییر کرد.
- متن انتخاب‌شده داخل خود باکس درس و compact chip پررنگ و قابل‌خواندن شد.
- Asset version برای شکستن cache افزایش یافت.

## Regression جدید
Playwright روی Production علاوه بر وجود داده، حالا واقعاً visibility، opacity، font size، عرض dropdown، قرارگیری داخل viewport و نمایش نام سرفصل انتخاب‌شده داخل خود lesson card را بررسی می‌کند.