### PR TITLE
Fix Select2 compatibility for visible Plan chapters

### DIFF
--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260807-1"
+ASSET_VERSION = "20260807-2"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
     ("plans/plan-time-grid.css", "data-plan-time-grid-style"),

--- a/plans/static/plans/plan-chapter-loader.js
+++ b/plans/static/plans/plan-chapter-loader.js
@@ -5,7 +5,7 @@
     return;
   }
 
-  const VERSION = '2026.08.07.1';
+  const VERSION = '2026.08.07.2';
   let synchronizeQueued = false;
 
   function currentStudentId() {
@@ -66,6 +66,18 @@
     }
   }
 
+  function activateChapterDropdown() {
+    // This project ships a Select2 build without the optional dropdownCss
+    // compatibility module. Add our styling hook after opening instead of using
+    // dropdownCssClass, which otherwise throws "No select2/compat/dropdownCss".
+    const $dropdown = $('.select2-dropdown:visible').last();
+    if (!$dropdown.length) {
+      return;
+    }
+    $dropdown.addClass('plan-chapter-dropdown');
+    keepDropdownInsideViewport();
+  }
+
   function configureChapterSelect(task) {
     const $task = $(task);
     const $select = $task.find('.task-chapter').first();
@@ -101,7 +113,6 @@
       // lesson card geometry.
       dropdownParent: $('body'),
       dropdownAutoWidth: true,
-      dropdownCssClass: 'plan-chapter-dropdown',
       width: '100%',
       theme: 'bootstrap-5',
       allowClear: true,
@@ -151,7 +162,7 @@
     $select
       .off('.planChapterVisibility')
       .on('select2:open.planChapterVisibility', function () {
-        window.requestAnimationFrame(keepDropdownInsideViewport);
+        window.requestAnimationFrame(activateChapterDropdown);
       });
 
     $select.attr('data-plan-chapter-loader-version', VERSION);


### PR DESCRIPTION
The chapter-visibility deployment exposed a compatibility issue in the project's Select2 build: using `dropdownCssClass` tries to load the optional `select2/compat/dropdownCss` module, which is not bundled and causes uncaught JavaScript errors.

This hotfix:
- removes the unsupported `dropdownCssClass` option;
- adds the `plan-chapter-dropdown` styling hook after `select2:open`, using the already-rendered dropdown;
- preserves the readable 260–390px dropdown width, RTL/multiline chapter labels and viewport clamping;
- bumps the Plan asset version so browsers receive the compatible script immediately.

The existing browser regression already fails on any uncaught JS error, so this directly covers the production failure observed in the previous deployment.