### PR TITLE
Fix student advisor consultation chat discovery

### DIFF
--- a/management/dashboard_security.py
+++ b/management/dashboard_security.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from rest_framework import status
 
 from accounts.models import Advisor, Student
+from management.serializers import UserProfileSerializer
 from management.views import ConversationListView, MessageListView
 from plans.advisor_access import assigned_students_for_advisor, effective_advisor_id
 
@@ -53,6 +54,34 @@ def _allowed_direct_user_ids(user) -> set[int]:
     return set()
 
 
+def _serialize_chat_user(user_obj, request):
+    if not user_obj:
+        return None
+
+    profile = getattr(user_obj, "profile", None)
+    profile_data = None
+    display_name = ""
+    if profile:
+        profile_data = UserProfileSerializer(
+            profile,
+            context={"request": request},
+        ).data
+        display_name = profile.get_full_name()
+
+    if not display_name:
+        display_name = user_obj.get_username() or f"کاربر {user_obj.pk}"
+
+    payload = {
+        "id": user_obj.pk,
+        "username": user_obj.get_username(),
+        "profile": profile_data,
+        "display_name": display_name,
+    }
+    if profile:
+        payload["role"] = getattr(profile, "role", None)
+    return payload
+
+
 class SecuredConversationListView(ConversationListView):
     """Keep conversation discovery aligned with current advisor assignments."""
 
@@ -63,6 +92,8 @@ class SecuredConversationListView(ConversationListView):
 
         allowed = _allowed_direct_user_ids(request.user)
         filtered = []
+        visible_user_ids = set()
+
         for item in response.data or []:
             conversation_id = str(item.get("id") or "")
             if not conversation_id.startswith("user:"):
@@ -73,6 +104,46 @@ class SecuredConversationListView(ConversationListView):
                 continue
             if other_id in allowed:
                 filtered.append(item)
+                visible_user_ids.add(other_id)
+
+        # ConversationListView historically seeded users only from the direct
+        # Student.advisor FK. Legacy dashboard assignments may have a valid active
+        # Course while that FK is still null. The centralized advisor policy above
+        # already resolves those records correctly, so make sure every currently
+        # allowed counterpart is present even before the first chat message exists.
+        missing_user_ids = allowed - visible_user_ids
+        if missing_user_ids:
+            current_user = (
+                User.objects.select_related("profile")
+                .filter(pk=request.user.pk)
+                .first()
+            )
+            current_payload = _serialize_chat_user(current_user, request)
+            missing_users = (
+                User.objects.filter(pk__in=missing_user_ids)
+                .select_related("profile")
+                .order_by("pk")
+            )
+            for other_user in missing_users:
+                other_payload = _serialize_chat_user(other_user, request)
+                filtered.append(
+                    {
+                        "id": f"user:{other_user.pk}",
+                        "type": "direct",
+                        "participants": [
+                            payload
+                            for payload in (current_payload, other_payload)
+                            if payload
+                        ],
+                        "display_name": (
+                            other_payload or {}
+                        ).get("display_name", f"کاربر {other_user.pk}"),
+                        "last_message": "",
+                        "last_message_at": None,
+                        "unread_count": 0,
+                    }
+                )
+
         response.data = filtered
         return response
 

--- a/management/test_assignment_access.py
+++ b/management/test_assignment_access.py
@@ -70,6 +70,13 @@ class DashboardAssignmentAccessTests(TestCase):
             content_type="application/json",
         )
 
+    def _assert_chat_list_contains(self, user: User, other_user: User):
+        self.client.force_login(user)
+        response = self.client.get("/api/chat/conversations/")
+        self.assertEqual(response.status_code, 200, response.content)
+        conversation_ids = {item.get("id") for item in response.json()}
+        self.assertIn(f"user:{other_user.pk}", conversation_ids)
+
     def _assert_advisor_can_use_student_across_surfaces(self):
         self.client.force_login(self.advisor_user)
 
@@ -108,19 +115,21 @@ class DashboardAssignmentAccessTests(TestCase):
         self.assertEqual(course.sessions.count(), 4)
 
         self._assert_advisor_can_use_student_across_surfaces()
+        self._assert_chat_list_contains(self.advisor_user, self.student_user)
 
         self.client.force_login(self.student_user)
         student_chat = self.client.get(
             f"/api/chat/messages/user:{self.advisor_user.pk}/"
         )
         self.assertEqual(student_chat.status_code, 200, student_chat.content)
+        self._assert_chat_list_contains(self.student_user, self.advisor_user)
 
         denied = self.client.get(
             f"/api/chat/messages/user:{self.other_advisor_user.pk}/"
         )
         self.assertEqual(denied.status_code, 403)
 
-    def test_legacy_course_assignment_is_allowed_across_plan_and_chat_before_repair(self):
+    def test_legacy_course_assignment_is_allowed_and_discoverable_before_repair(self):
         Course.objects.create(
             student=self.student,
             advisor=self.advisor,
@@ -132,6 +141,8 @@ class DashboardAssignmentAccessTests(TestCase):
         self.assertIsNone(self.student.advisor_id)
 
         self._assert_advisor_can_use_student_across_surfaces()
+        self._assert_chat_list_contains(self.advisor_user, self.student_user)
+        self._assert_chat_list_contains(self.student_user, self.advisor_user)
 
         self.client.force_login(self.student_user)
         response = self.client.get(


### PR DESCRIPTION
## What changed
- make the secured conversation list seed every currently allowed advisor/student counterpart from the centralized advisor access policy
- preserve existing message metadata while adding missing zero-message conversations
- add regression coverage for both canonical and legacy Course-only assignments

## Root cause
Legacy dashboard assignments could have a valid active `Course` while `Student.advisor` was still null. Direct message authorization already used the centralized fallback policy, but conversation discovery inherited the old FK-only list logic. As a result, a student/advisor pair could be authorized yet not appear in the consultation/chat UI before their first message.

## Impact
Students and advisors now see each other in the consultation list whenever the central assignment policy says they are connected, including legacy records before the repair command backfills `Student.advisor`. Unrelated advisors remain denied.