### PR TITLE
Color initial lesson cards in Plan sidebar

### DIFF
--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260813-1"
+ASSET_VERSION = "20260813-2"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
     ("plans/plan-time-grid.css", "data-plan-time-grid-style"),

--- a/plans/static/plans/plan-modern-ui.js
+++ b/plans/static/plans/plan-modern-ui.js
@@ -13,7 +13,7 @@
   function calendarIcon() {
     return (
       '<svg viewBox="0 0 24 24" aria-hidden="true">' +
-        '<path d="M7 3v3M17 3v3M4.5 9h15M5 5h14a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H5a2 2 0 0 0-2 2.5v-16Z"/>' +
+        '<path d="M7 3v3M17 3v3M4.5 9h15M5 5h14a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Z"/>' +
         '<path d="m8 14 2 2 5-5"/>' +
       '</svg>'
     );
@@ -110,9 +110,9 @@
         return;
       }
 
-      // Both the server-rendered cards and the AJAX-rendered cards carry
-      // data-lesson-name. Apply the canonical subject color with inline
-      // !important priority so the modern UI background cannot hide it.
+      // Both the initial Django cards and AJAX-rendered cards carry
+      // data-lesson-name. Apply the canonical subject color at inline-important
+      // priority so the modern UI background cannot hide it.
       this.style.setProperty(
         'background',
         'linear-gradient(135deg, rgba(255,255,255,.22), rgba(255,255,255,.08)), ' + color,
@@ -230,7 +230,7 @@
     if (typeof MOBILE_QUERY.addEventListener === 'function') {
       MOBILE_QUERY.addEventListener('change', onQueryChange);
     } else if (typeof MOBILE_QUERY.addListener === 'function') {
-      MOBILE_QUERY.addListener('change', onQueryChange);
+      MOBILE_QUERY.addListener(onQueryChange);
     }
   }
 

--- a/plans/static/plans/plan-modern-ui.js
+++ b/plans/static/plans/plan-modern-ui.js
@@ -5,14 +5,15 @@
     return;
   }
 
-  const VERSION = '2026.08.13.1';
+  const VERSION = '2026.08.13.2';
   const MOBILE_QUERY = window.matchMedia('(max-width: 760px)');
+  const LESSON_CARD_SELECTOR = '.task[data-lesson-name]';
   let subjectPaletteObserver = null;
 
   function calendarIcon() {
     return (
       '<svg viewBox="0 0 24 24" aria-hidden="true">' +
-        '<path d="M7 3v3M17 3v3M4.5 9h15M5 5h14a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Z"/>' +
+        '<path d="M7 3v3M17 3v3M4.5 9h15M5 5h14a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H5a2 2 0 0 0-2 2.5v-16Z"/>' +
         '<path d="m8 14 2 2 5-5"/>' +
       '</svg>'
     );
@@ -92,9 +93,9 @@
   function paintSubjectPalette(root) {
     const colors = window.subjectColors || {};
     const $scope = root ? $(root) : $(document);
-    const $tasks = $scope.is('.plan-lesson-palette')
+    const $tasks = $scope.is(LESSON_CARD_SELECTOR)
       ? $scope
-      : $scope.find('.subjects-box .plan-lesson-palette');
+      : $scope.find(LESSON_CARD_SELECTOR);
 
     $tasks.each(function () {
       const $task = $(this);
@@ -109,9 +110,9 @@
         return;
       }
 
-      // plan-modern-ui.css intentionally owns the card shape with an !important
-      // background. Re-apply the canonical subject color at inline-important
-      // priority so the sidebar stays visually consistent with calendar cards.
+      // Both the server-rendered cards and the AJAX-rendered cards carry
+      // data-lesson-name. Apply the canonical subject color with inline
+      // !important priority so the modern UI background cannot hide it.
       this.style.setProperty(
         'background',
         'linear-gradient(135deg, rgba(255,255,255,.22), rgba(255,255,255,.08)), ' + color,
@@ -229,7 +230,7 @@
     if (typeof MOBILE_QUERY.addEventListener === 'function') {
       MOBILE_QUERY.addEventListener('change', onQueryChange);
     } else if (typeof MOBILE_QUERY.addListener === 'function') {
-      MOBILE_QUERY.addListener(onQueryChange);
+      MOBILE_QUERY.addListener('change', onQueryChange);
     }
   }
 


### PR DESCRIPTION
The previous fix targeted only `.plan-lesson-palette`, which is added to lesson cards after the AJAX/runtime render. The initial Django-rendered cards visible immediately on `/plan/` only have `.task` plus `data-lesson-name`, so they stayed blue.

This changes the color sync selector to every lesson card carrying `data-lesson-name`, covering both the initial server-rendered list and later AJAX-rendered lists. The subject color is still applied with inline `!important` priority to beat the modern UI background rule. Asset version is bumped again to avoid stale browser cache.