### PR TITLE
Fix sequential Plan lesson drop lag

### DIFF
--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -8,6 +8,7 @@ on:
       - 'deploy/plan_e2e.py'
       - 'deploy/plan_e2e_runner.py'
       - 'deploy/plan_real_interaction_e2e.py'
+      - 'deploy/plan_sequential_drop_perf_e2e.py'
       - 'deploy/plan_school_drag_e2e.py'
       - 'deploy/plan_time_grid_e2e.py'
       - 'deploy/plan_task_independence_e2e.py'
@@ -34,6 +35,7 @@ jobs:
 
       - name: Validate Plan source syntax
         run: |
+          node --check plans/static/plans/plan-performance-guard.js
           node --check plans/static/plans/plan-runtime.js
           node --check plans/static/plans/plan-secondary.js
           node --check plans/static/plans/plan-time-grid.js
@@ -51,6 +53,7 @@ jobs:
             deploy/plan_e2e.py \
             deploy/plan_e2e_runner.py \
             deploy/plan_real_interaction_e2e.py \
+            deploy/plan_sequential_drop_perf_e2e.py \
             deploy/plan_school_drag_e2e.py \
             deploy/plan_time_grid_e2e.py \
             deploy/plan_task_independence_e2e.py \
@@ -63,6 +66,13 @@ jobs:
             plans/plan_page.py \
             plans/weekly_plans.py \
             plans/weekly_plans_v2.py
+          python3 - <<'PY'
+          from pathlib import Path
+          source = Path('plans/plan_page.py').read_text(encoding='utf-8')
+          guard = source.index('plans/plan-performance-guard.js')
+          runtime = source.index('plans/plan-runtime.js')
+          assert guard < runtime, 'performance guard must load before Plan runtime scripts'
+          PY
 
       - name: Install Python dependencies
         shell: bash

--- a/.github/workflows/verify-plan-interactions.yml
+++ b/.github/workflows/verify-plan-interactions.yml
@@ -53,6 +53,10 @@ jobs:
             > plan-real-interaction-output.txt 2>&1
           core_status=$?
 
+          .plan-real-browser-venv/bin/python deploy/plan_sequential_drop_perf_e2e.py \
+            > plan-sequential-drop-perf-output.txt 2>&1
+          sequential_perf_status=$?
+
           .plan-real-browser-venv/bin/python deploy/plan_school_drag_e2e.py \
             > plan-school-drag-output.txt 2>&1
           school_status=$?
@@ -79,6 +83,8 @@ jobs:
 
           echo '===== Core real interactions ====='
           cat plan-real-interaction-output.txt
+          echo '===== Sequential lesson drop performance ====='
+          cat plan-sequential-drop-perf-output.txt
           echo '===== School-block drag interactions ====='
           cat plan-school-drag-output.txt
           echo '===== Time grid and lesson toolbar ====='
@@ -93,7 +99,7 @@ jobs:
           cat plan-chapter-visibility-output.txt
 
           status=0
-          if [ "$core_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ] || [ "$independence_status" -ne 0 ] || [ "$responsive_status" -ne 0 ] || [ "$chapter_snap_status" -ne 0 ] || [ "$chapter_visibility_status" -ne 0 ]; then
+          if [ "$core_status" -ne 0 ] || [ "$sequential_perf_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ] || [ "$independence_status" -ne 0 ] || [ "$responsive_status" -ne 0 ] || [ "$chapter_snap_status" -ne 0 ] || [ "$chapter_visibility_status" -ne 0 ]; then
             status=1
           fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
@@ -106,6 +112,7 @@ jobs:
           name: plan-real-interaction-output
           path: |
             plan-real-interaction-output.txt
+            plan-sequential-drop-perf-output.txt
             plan-school-drag-output.txt
             plan-time-grid-output.txt
             plan-task-independence-output.txt
@@ -127,10 +134,10 @@ jobs:
           set -euo pipefail
           if [ "${TEST_STATUS:-1}" = "0" ]; then
             STATE='success'
-            DESCRIPTION='Plan interactions, visible chapters, 15-minute snap and responsive UI passed.'
+            DESCRIPTION='Plan interactions, sequential drop latency, visible chapters, snap and responsive UI passed.'
           else
             STATE='failure'
-            DESCRIPTION='Plan interaction, chapter visibility, snap or responsive regression failed.'
+            DESCRIPTION='Plan interaction, sequential drop latency, chapter visibility, snap or responsive regression failed.'
           fi
 
           jq -n \

--- a/deploy/plan_sequential_drop_perf_e2e.py
+++ b/deploy/plan_sequential_drop_perf_e2e.py
@@ -119,6 +119,7 @@ def main() -> int:
         first_task = first_target.locator(
             f':scope > .calendar-task[data-lesson-id="{first_id}"]'
         ).first
+        first_task.wait_for(state="attached", timeout=3_000)
         page.wait_for_function(
             "element => Boolean(element && element.querySelector('.task-chapter[data-plan-chapter-loader-version]'))",
             arg=first_task.element_handle(),
@@ -149,11 +150,7 @@ def main() -> int:
         second_task = second_target.locator(
             f':scope > .calendar-task[data-lesson-id="{second_id}"]'
         ).first
-        page.wait_for_function(
-            "element => Boolean(element && element.isConnected)",
-            arg=second_task.element_handle(),
-            timeout=3_000,
-        )
+        second_task.wait_for(state="attached", timeout=3_000)
         elapsed = time.perf_counter() - started
 
         require(second_task.count() == 1, "second lesson appears after chapter selection")

--- a/deploy/plan_sequential_drop_perf_e2e.py
+++ b/deploy/plan_sequential_drop_perf_e2e.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import os
+import sys
+import time
+from urllib.parse import urljoin
+
+from playwright.sync_api import Locator, Page, sync_playwright
+
+
+BASE_URL = os.environ.get(
+    "PLAN_BASE_URL", "https://panel.kimiagarkhoone.com"
+).rstrip("/") + "/"
+USERNAME = os.environ.get("PLAN_USERNAME", "").strip()
+PASSWORD = os.environ.get("PLAN_PASSWORD", "")
+TEST_WEEK = os.environ.get("PLAN_TEST_WEEK", "1499-02-01")
+STUDENT_LABEL = os.environ.get("PLAN_STUDENT_LABEL", "نمونه تجربی دوازدهم")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+    print(f"PASS: {message}")
+
+
+def drag_palette_to(page: Page, source: Locator, target: Locator, desired_top: float) -> None:
+    source.scroll_into_view_if_needed()
+    source_box = source.bounding_box()
+    target_box = target.bounding_box()
+    if not source_box or not target_box:
+        raise AssertionError("Palette or target is not visible")
+
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2,
+        source_box["y"] + source_box["height"] / 2,
+    )
+    page.mouse.down()
+    page.mouse.move(
+        source_box["x"] + source_box["width"] / 2 + 6,
+        source_box["y"] + source_box["height"] / 2 + 6,
+        steps=3,
+    )
+    page.mouse.move(
+        target_box["x"] + target_box["width"] / 2,
+        target_box["y"] + desired_top,
+        steps=20,
+    )
+    page.mouse.up()
+
+
+def load_week(page: Page) -> None:
+    page.select_option("#student-select", label=STUDENT_LABEL)
+    page.evaluate(
+        """
+        value => {
+          window.jQuery('#weekSelector')
+            .val(value)
+            .trigger('input')
+            .trigger('change');
+        }
+        """,
+        TEST_WEEK,
+    )
+    page.click("#loadWeek")
+    page.wait_for_function(
+        "window.planRuntimeState && window.planRuntimeState.loaded && !window.planRuntimeState.loading",
+        timeout=30_000,
+    )
+    page.wait_for_function(
+        "window.planPerformanceGuard && window.planPerformanceGuard.stats.blockedIntervals >= 3",
+        timeout=10_000,
+    )
+
+
+def clear_calendar(page: Page) -> None:
+    page.evaluate(
+        """
+        () => window.jQuery('.calendar .calendar-task').remove()
+        """
+    )
+    page.wait_for_timeout(100)
+
+
+def main() -> int:
+    if not USERNAME or not PASSWORD:
+        print("PLAN_USERNAME and PLAN_PASSWORD are required.", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(locale="fa-IR", viewport={"width": 1700, "height": 1050})
+        page = context.new_page()
+        page.on("pageerror", lambda error: errors.append(str(error)))
+        page.on("dialog", lambda dialog: dialog.accept())
+
+        page.goto(urljoin(BASE_URL, "login/"), wait_until="domcontentloaded", timeout=30_000)
+        page.fill("#username", USERNAME)
+        page.fill("#password", PASSWORD)
+        page.click('form button[type="submit"]')
+        page.wait_for_url("**/plan/", timeout=30_000)
+        page.wait_for_function("window.jQuery && window.jQuery.ui", timeout=20_000)
+        load_week(page)
+        clear_calendar(page)
+
+        palettes = page.locator(".subjects-box .plan-lesson-palette")
+        require(palettes.count() >= 2, "at least two lesson palette items are available")
+        first_palette = palettes.nth(0)
+        second_palette = palettes.nth(1)
+        first_id = first_palette.get_attribute("data-lesson-id")
+        second_id = second_palette.get_attribute("data-lesson-id")
+        require(bool(first_id and second_id and first_id != second_id), "two distinct lessons are available")
+
+        containers = page.locator(".calendar .task-container")
+        first_target = containers.nth(0)
+        second_target = containers.nth(1)
+
+        drag_palette_to(page, first_palette, first_target, 210)
+        first_task = first_target.locator(
+            f':scope > .calendar-task[data-lesson-id="{first_id}"]'
+        ).first
+        page.wait_for_function(
+            "element => Boolean(element && element.querySelector('.task-chapter[data-plan-chapter-loader-version]'))",
+            arg=first_task.element_handle(),
+            timeout=10_000,
+        )
+        require(first_task.count() == 1, "first lesson is dropped")
+
+        # Reproduce the real slow path: choose a chapter (and tests so the card
+        # can compact), then immediately drop a different lesson.
+        page.evaluate(
+            """
+            element => {
+              const $task = window.jQuery(element);
+              const $chapter = $task.find('.task-chapter');
+              if (!$chapter.find('option[value="perf-chapter"]').length) {
+                $chapter.append(new Option('فصل تست سرعت', 'perf-chapter', true, true));
+              }
+              $chapter.val('perf-chapter').trigger('change').trigger('select2:select');
+              $task.find('.task-extra').val('20').trigger('change');
+            }
+            """,
+            first_task.element_handle(),
+        )
+        page.wait_for_timeout(100)
+
+        started = time.perf_counter()
+        drag_palette_to(page, second_palette, second_target, 315)
+        second_task = second_target.locator(
+            f':scope > .calendar-task[data-lesson-id="{second_id}"]'
+        ).first
+        page.wait_for_function(
+            "element => Boolean(element && element.isConnected)",
+            arg=second_task.element_handle(),
+            timeout=3_000,
+        )
+        elapsed = time.perf_counter() - started
+
+        require(second_task.count() == 1, "second lesson appears after chapter selection")
+        require(
+            elapsed < 2.5,
+            f"second lesson drop stays responsive ({elapsed:.2f}s < 2.5s)",
+        )
+        require(
+            not errors,
+            "sequential lesson flow has no uncaught JavaScript errors: " + " | ".join(errors),
+        )
+
+        stats = page.evaluate("() => window.planPerformanceGuard.stats")
+        print(
+            "Performance guard stats: "
+            f"blockedIntervals={stats['blockedIntervals']}, "
+            f"filteredMutationBatches={stats['filteredMutationBatches']}"
+        )
+
+        context.close()
+        browser.close()
+
+    print("Sequential Plan drop performance regression completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260813-3"
+ASSET_VERSION = "20260814-1"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
     ("plans/plan-time-grid.css", "data-plan-time-grid-style"),
@@ -17,6 +17,7 @@ STYLE_PATHS = (
     ("plans/plan-quarter-snap-feedback.css", "data-plan-quarter-snap-feedback-style"),
 )
 RUNTIME_PATHS = (
+    ("plans/plan-performance-guard.js", "data-plan-performance-guard"),
     ("plans/plan-runtime.js", "data-plan-runtime"),
     ("plans/plan-secondary.js", "data-plan-secondary"),
     ("plans/plan-time-grid.js", "data-plan-time-grid"),

--- a/plans/static/plans/plan-performance-guard.js
+++ b/plans/static/plans/plan-performance-guard.js
@@ -1,0 +1,112 @@
+(function (window, document) {
+  'use strict';
+
+  if (window.__planPerformanceGuardInstalled) {
+    return;
+  }
+  window.__planPerformanceGuardInstalled = true;
+
+  const VERSION = '2026.08.14.1';
+  const blockedDelays = new Set([250, 350, 400, 500]);
+  const nativeSetInterval = window.setInterval.bind(window);
+  const NativeMutationObserver = window.MutationObserver;
+  let suppressedTimerId = -1;
+
+  const stats = {
+    blockedIntervals: 0,
+    filteredMutationBatches: 0
+  };
+
+  function isLegacyPlanSynchronizer(handler, delay) {
+    return (
+      typeof handler === 'function' &&
+      handler.name === 'synchronize' &&
+      blockedDelays.has(Number(delay))
+    );
+  }
+
+  // Several compatibility layers used to rescan every calendar task every
+  // 250/350/400/500ms. Their MutationObservers and input hooks already keep new
+  // tasks patched, so these loops only add continuous CPU/layout pressure.
+  window.setInterval = function (handler, delay) {
+    if (isLegacyPlanSynchronizer(handler, delay)) {
+      stats.blockedIntervals += 1;
+      return suppressedTimerId--;
+    }
+    return nativeSetInterval.apply(window, arguments);
+  };
+
+  function elementTouchesCalendarStructure(node) {
+    if (!node || node.nodeType !== 1) {
+      return false;
+    }
+    if (
+      node.matches &&
+      node.matches('.calendar-task, .task-container, .day-column')
+    ) {
+      return true;
+    }
+    return Boolean(
+      node.querySelector &&
+      node.querySelector('.calendar-task, .task-container')
+    );
+  }
+
+  function mutationTouchesCalendarStructure(mutation) {
+    const nodes = [];
+    mutation.addedNodes.forEach(function (node) { nodes.push(node); });
+    mutation.removedNodes.forEach(function (node) { nodes.push(node); });
+    return nodes.some(elementTouchesCalendarStructure);
+  }
+
+  // Calendar observers only need structural task/day changes. Select2 updates
+  // its internal DOM heavily while a chapter is selected; letting every one of
+  // those mutations wake all interaction layers creates the multi-second stall
+  // seen before dropping the next lesson.
+  if (typeof NativeMutationObserver === 'function') {
+    function PlanMutationObserver(callback) {
+      let filterCalendarMutations = false;
+      const observer = new NativeMutationObserver(function (mutations, nativeObserver) {
+        if (!filterCalendarMutations) {
+          callback(mutations, nativeObserver);
+          return;
+        }
+
+        const filtered = mutations.filter(mutationTouchesCalendarStructure);
+        if (!filtered.length) {
+          stats.filteredMutationBatches += 1;
+          return;
+        }
+        callback(filtered, nativeObserver);
+      });
+
+      const nativeObserve = observer.observe.bind(observer);
+      observer.observe = function (target, options) {
+        filterCalendarMutations = Boolean(
+          target &&
+          target.nodeType === 1 &&
+          target.matches &&
+          target.matches('.calendar') &&
+          options &&
+          options.childList &&
+          options.subtree
+        );
+        return nativeObserve(target, options);
+      };
+      return observer;
+    }
+
+    PlanMutationObserver.prototype = NativeMutationObserver.prototype;
+    window.MutationObserver = PlanMutationObserver;
+  }
+
+  if (document.body) {
+    document.body.setAttribute('data-plan-performance-guard-version', VERSION);
+  }
+
+  window.planPerformanceGuard = {
+    version: VERSION,
+    stats: stats,
+    nativeSetInterval: nativeSetInterval
+  };
+})(window, document);


### PR DESCRIPTION
The Plan page still stalled for around 10 seconds in the sequence: drop one lesson, choose a chapter, then drop another lesson.

Root cause: four compatibility layers were each running a full-calendar synchronize loop every 250/350/400/500ms, while calendar-wide MutationObservers also woke on Select2's internal DOM changes. Together this caused repeated full rescans and layout work, especially immediately after chapter selection.

This PR adds a performance guard that loads before every Plan runtime, suppresses only those legacy synchronize polling loops, and filters calendar MutationObserver callbacks so internal Select2 mutations do not wake all interaction layers. Structural task/day additions and removals still pass through normally.

It also adds a production Playwright regression reproducing the exact sequence and requires the second lesson to appear in under 2.5 seconds. Asset version is bumped to bypass stale browser cache.