### PR TITLE
Fix Plan PDF titles, recurring classes and saved-plan reuse

### DIFF
--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -9,6 +9,7 @@ on:
       - 'deploy/plan_e2e_runner.py'
       - 'deploy/plan_real_interaction_e2e.py'
       - 'deploy/plan_sequential_drop_perf_e2e.py'
+      - 'deploy/plan_persistence_e2e.py'
       - 'deploy/plan_school_drag_e2e.py'
       - 'deploy/plan_time_grid_e2e.py'
       - 'deploy/plan_task_independence_e2e.py'
@@ -38,6 +39,7 @@ jobs:
           node --check plans/static/plans/plan-performance-guard.js
           node --check plans/static/plans/plan-runtime.js
           node --check plans/static/plans/plan-secondary.js
+          node --check plans/static/plans/plan-persistence-fixes.js
           node --check plans/static/plans/plan-time-grid.js
           node --check plans/static/plans/plan-interactions.js
           node --check plans/static/plans/plan-manual-resize.js
@@ -54,6 +56,7 @@ jobs:
             deploy/plan_e2e_runner.py \
             deploy/plan_real_interaction_e2e.py \
             deploy/plan_sequential_drop_perf_e2e.py \
+            deploy/plan_persistence_e2e.py \
             deploy/plan_school_drag_e2e.py \
             deploy/plan_time_grid_e2e.py \
             deploy/plan_task_independence_e2e.py \
@@ -64,6 +67,7 @@ jobs:
             plans/chapter_catalog.py \
             plans/lesson_catalog.py \
             plans/plan_page.py \
+            plans/plan_reuse.py \
             plans/weekly_plans.py \
             plans/weekly_plans_v2.py
           python3 - <<'PY'
@@ -71,7 +75,9 @@ jobs:
           source = Path('plans/plan_page.py').read_text(encoding='utf-8')
           guard = source.index('plans/plan-performance-guard.js')
           runtime = source.index('plans/plan-runtime.js')
+          persistence = source.index('plans/plan-persistence-fixes.js')
           assert guard < runtime, 'performance guard must load before Plan runtime scripts'
+          assert runtime < persistence, 'persistence fixes must load after canonical Plan runtime'
           PY
 
       - name: Install Python dependencies
@@ -92,6 +98,7 @@ jobs:
           set +e
           .venv/bin/python manage.py test \
             plans.test_plan_runtime \
+            plans.test_plan_persistence \
             plans.test_plan_secondary \
             plans.test_plan_defaults \
             plans.test_lesson_catalog \

--- a/.github/workflows/verify-plan-interactions.yml
+++ b/.github/workflows/verify-plan-interactions.yml
@@ -57,6 +57,10 @@ jobs:
             > plan-sequential-drop-perf-output.txt 2>&1
           sequential_perf_status=$?
 
+          .plan-real-browser-venv/bin/python deploy/plan_persistence_e2e.py \
+            > plan-persistence-output.txt 2>&1
+          persistence_status=$?
+
           .plan-real-browser-venv/bin/python deploy/plan_school_drag_e2e.py \
             > plan-school-drag-output.txt 2>&1
           school_status=$?
@@ -85,6 +89,8 @@ jobs:
           cat plan-real-interaction-output.txt
           echo '===== Sequential lesson drop performance ====='
           cat plan-sequential-drop-perf-output.txt
+          echo '===== Export, recurring classes and saved-plan persistence ====='
+          cat plan-persistence-output.txt
           echo '===== School-block drag interactions ====='
           cat plan-school-drag-output.txt
           echo '===== Time grid and lesson toolbar ====='
@@ -99,7 +105,7 @@ jobs:
           cat plan-chapter-visibility-output.txt
 
           status=0
-          if [ "$core_status" -ne 0 ] || [ "$sequential_perf_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ] || [ "$independence_status" -ne 0 ] || [ "$responsive_status" -ne 0 ] || [ "$chapter_snap_status" -ne 0 ] || [ "$chapter_visibility_status" -ne 0 ]; then
+          if [ "$core_status" -ne 0 ] || [ "$sequential_perf_status" -ne 0 ] || [ "$persistence_status" -ne 0 ] || [ "$school_status" -ne 0 ] || [ "$grid_status" -ne 0 ] || [ "$independence_status" -ne 0 ] || [ "$responsive_status" -ne 0 ] || [ "$chapter_snap_status" -ne 0 ] || [ "$chapter_visibility_status" -ne 0 ]; then
             status=1
           fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
@@ -113,6 +119,7 @@ jobs:
           path: |
             plan-real-interaction-output.txt
             plan-sequential-drop-perf-output.txt
+            plan-persistence-output.txt
             plan-school-drag-output.txt
             plan-time-grid-output.txt
             plan-task-independence-output.txt
@@ -134,10 +141,10 @@ jobs:
           set -euo pipefail
           if [ "${TEST_STATUS:-1}" = "0" ]; then
             STATE='success'
-            DESCRIPTION='Plan interactions, sequential drop latency, visible chapters, snap and responsive UI passed.'
+            DESCRIPTION='Plan interactions, persistence, export titles, recurring classes and responsive UI passed.'
           else
             STATE='failure'
-            DESCRIPTION='Plan interaction, sequential drop latency, chapter visibility, snap or responsive regression failed.'
+            DESCRIPTION='Plan interaction, persistence, export, recurrence or responsive regression failed.'
           fi
 
           jq -n \

--- a/deploy/plan_persistence_e2e.py
+++ b/deploy/plan_persistence_e2e.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+import sys
+from urllib.parse import urljoin
+
+from playwright.sync_api import sync_playwright
+
+
+BASE_URL = os.environ.get(
+    "PLAN_BASE_URL", "https://panel.kimiagarkhoone.com"
+).rstrip("/") + "/"
+USERNAME = os.environ.get("PLAN_USERNAME", "").strip()
+PASSWORD = os.environ.get("PLAN_PASSWORD", "")
+TEST_WEEK = os.environ.get("PLAN_TEST_WEEK", "1499-02-01")
+STUDENT_LABEL = os.environ.get("PLAN_STUDENT_LABEL", "نمونه تجربی دوازدهم")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+    print(f"PASS: {message}")
+
+
+def load_week(page) -> None:
+    page.select_option("#student-select", label=STUDENT_LABEL)
+    page.evaluate(
+        """
+        value => {
+          window.jQuery('#weekSelector')
+            .val(value)
+            .trigger('input')
+            .trigger('change');
+        }
+        """,
+        TEST_WEEK,
+    )
+    page.click("#loadWeek")
+    page.wait_for_function(
+        "window.planRuntimeState && window.planRuntimeState.loaded && !window.planRuntimeState.loading",
+        timeout=30_000,
+    )
+    page.wait_for_function(
+        "window.planPersistenceFixes && window.planPersistenceFixes.version === '2026.08.18.1'",
+        timeout=15_000,
+    )
+
+
+def main() -> int:
+    if not USERNAME or not PASSWORD:
+        print("PLAN_USERNAME and PLAN_PASSWORD are required.", file=sys.stderr)
+        return 2
+
+    page_errors: list[str] = []
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(locale="fa-IR", viewport={"width": 1700, "height": 1050})
+        page = context.new_page()
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        page.on("dialog", lambda dialog: dialog.accept())
+
+        page.goto(urljoin(BASE_URL, "login/"), wait_until="domcontentloaded", timeout=30_000)
+        page.fill("#username", USERNAME)
+        page.fill("#password", PASSWORD)
+        page.click('form button[type="submit"]')
+        page.wait_for_url("**/plan/", timeout=30_000)
+        page.wait_for_function("window.jQuery && window.jQuery.ui", timeout=20_000)
+        load_week(page)
+
+        export_result = page.evaluate(
+            """
+            () => {
+              const $ = window.jQuery;
+              const $container = $('.calendar .task-container').first();
+              const makeEditable = (type, value, top) => {
+                const $task = $('<div class="calendar-task"></div>')
+                  .attr('data-box-type', type)
+                  .css({position: 'absolute', top: top + 'px', height: '35px', left: '5%'});
+                const $input = $('<input type="text" class="task-title task-inp editable">');
+                // Reproduce the actual browser problem: update the live property
+                // without updating the serialized HTML value attribute.
+                $input[0].value = value;
+                $task.append($input).append('<div class="time-label"></div>');
+                $container.append($task);
+                return $input[0];
+              };
+
+              const eventInput = makeEditable('ایونت', 'کلاس فیزیک یازدهم خروجی', 420);
+              const assignmentInput = makeEditable(
+                'تکلیف',
+                'آمادگی و تکلیف کلاس فیزیک یازدهم خروجی',
+                472.5
+              );
+              const before = {
+                eventAttr: eventInput.getAttribute('value'),
+                assignmentAttr: assignmentInput.getAttribute('value')
+              };
+
+              window.planPersistenceFixes.synchronizeTitlesForExport();
+              const html = $('.calendar-wrapper').clone().prop('outerHTML');
+              return {
+                before,
+                eventAttr: eventInput.getAttribute('value'),
+                assignmentAttr: assignmentInput.getAttribute('value'),
+                containsEvent: html.includes('کلاس فیزیک یازدهم خروجی'),
+                containsAssignment: html.includes('آمادگی و تکلیف کلاس فیزیک یازدهم خروجی')
+              };
+            }
+            """
+        )
+        require(
+            export_result["before"]["eventAttr"] in (None, ""),
+            "test reproduces a live event title that was absent from serialized HTML",
+        )
+        require(
+            export_result["eventAttr"] == "کلاس فیزیک یازدهم خروجی",
+            "event title is synchronized before PDF cloning",
+        )
+        require(
+            export_result["assignmentAttr"] == "آمادگی و تکلیف کلاس فیزیک یازدهم خروجی",
+            "event-derived assignment title is synchronized before PDF cloning",
+        )
+        require(
+            export_result["containsEvent"] and export_result["containsAssignment"],
+            "serialized PDF calendar clone contains both visible titles",
+        )
+
+        recurring_result = page.evaluate(
+            """
+            async () => {
+              const $ = window.jQuery;
+              const state = window.planRuntimeState;
+              const defaults = await $.getJSON('/get_default_events/', {
+                student_id: state.studentId
+              });
+
+              $('.calendar .calendar-task').remove();
+              const $first = $('.calendar .task-container').first();
+              const $saved = $('<div class="calendar-task event-task"></div>')
+                .attr('data-box-type', 'ایونت')
+                .css({position: 'absolute', top: '560px', height: '35px', left: '5%'})
+                .append('<input type="text" class="task-title task-inp editable" value="رویداد ذخیره‌شده غیرتکراری">')
+                .append('<div class="time-label"></div>');
+              $first.append($saved);
+
+              const added = window.planPersistenceFixes.mergeRecurringEvents(defaults);
+              const recurring = $('.calendar .calendar-task[data-recurring-default="true"]');
+              const savedStillVisible = $('.calendar .calendar-task .task-title').filter(function () {
+                return String($(this).val() || $(this).text() || '').trim() === 'رویداد ذخیره‌شده غیرتکراری';
+              }).length > 0;
+              return {
+                defaults: defaults.length,
+                added,
+                recurring: recurring.length,
+                savedStillVisible
+              };
+            }
+            """
+        )
+        require(recurring_result["defaults"] > 0, "student has recurring default events")
+        require(
+            recurring_result["added"] > 0 and recurring_result["recurring"] > 0,
+            "recurring classes are merged even when another saved task already exists",
+        )
+        require(
+            recurring_result["savedStillVisible"],
+            "merging recurring classes preserves the saved weekly task",
+        )
+        require(
+            not page_errors,
+            "persistence flow has no uncaught JavaScript errors: " + " | ".join(page_errors),
+        )
+
+        context.close()
+        browser.close()
+
+    print("Plan persistence regression completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260814-1"
+ASSET_VERSION = "20260818-1"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
     ("plans/plan-time-grid.css", "data-plan-time-grid-style"),
@@ -20,6 +20,7 @@ RUNTIME_PATHS = (
     ("plans/plan-performance-guard.js", "data-plan-performance-guard"),
     ("plans/plan-runtime.js", "data-plan-runtime"),
     ("plans/plan-secondary.js", "data-plan-secondary"),
+    ("plans/plan-persistence-fixes.js", "data-plan-persistence-fixes"),
     ("plans/plan-time-grid.js", "data-plan-time-grid"),
     ("plans/plan-interactions.js", "data-plan-interactions"),
     ("plans/plan-manual-resize.js", "data-plan-manual-resize"),

--- a/plans/plan_reuse.py
+++ b/plans/plan_reuse.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from django.contrib.auth.decorators import login_required
+from django.http import HttpRequest, JsonResponse
+
+from plans.models import WeeklyReport, WeeklyReportDetail
+from plans.weekly_plans import _student_or_response, normalize_day_name
+
+
+@login_required
+def get_last_weekly_report(request: HttpRequest):
+    """Return the latest reusable study plan, not merely the latest report row.
+
+    A newer report may legitimately contain only events/classes (or no details).
+    The old endpoint selected that row first and then filtered it down to study
+    boxes, which made the UI say that no saved plan existed even when an older
+    report contained a complete lesson plan.
+    """
+
+    student, error = _student_or_response(request, request.GET.get("student_id"))
+    if error:
+        return error
+
+    report = (
+        WeeklyReport.objects.filter(
+            student=student,
+            details__box__lesson__isnull=False,
+        )
+        .distinct()
+        .order_by("-week_start", "-pk")
+        .first()
+    )
+    if report is None:
+        return JsonResponse({"report_id": None, "tasks": []})
+
+    details = (
+        WeeklyReportDetail.objects.filter(
+            report=report,
+            box__lesson__isnull=False,
+        )
+        .select_related(
+            "box__lesson__grade",
+            "box__lesson__lesson_type",
+            "box__chapter",
+        )
+        .order_by("start_time", "pk")
+    )
+
+    tasks = []
+    for detail in details:
+        box = detail.box
+        lesson = box.lesson
+        if lesson is None:
+            continue
+        chapter = box.chapter
+        duration_minutes = box.duration_minutes
+        if not duration_minutes:
+            duration_minutes = max(
+                1,
+                int((detail.end_time - detail.start_time).total_seconds() // 60),
+            )
+        day_name = normalize_day_name(detail.day_of_week)
+        if day_name is None:
+            # Historic rows occasionally used an alias. Falling back to the
+            # actual calendar date is safer than silently mapping to Saturday.
+            weekday_map = {
+                5: "شنبه",
+                6: "یک‌شنبه",
+                0: "دوشنبه",
+                1: "سه‌شنبه",
+                2: "چهارشنبه",
+                3: "پنج‌شنبه",
+                4: "جمعه",
+            }
+            day_name = weekday_map[detail.start_time.weekday()]
+
+        tasks.append(
+            {
+                "lesson_id": lesson.pk,
+                "lesson_name": lesson.name,
+                "chapter_id": chapter.pk if chapter else None,
+                "chapter_text": chapter.name if chapter else "",
+                "optional_tests_count": box.optional_tests_count or 0,
+                "duration_minutes": duration_minutes,
+                "grade_id": lesson.grade_id,
+                "lesson_type": lesson.lesson_type.name if lesson.lesson_type else "",
+                "grade": lesson.grade_id,
+                "day_of_week": day_name,
+            }
+        )
+
+    return JsonResponse(
+        {
+            "report_id": report.pk,
+            "week_start": report.week_start.isoformat(),
+            "week_end": report.week_end.isoformat(),
+            "tasks": tasks,
+        }
+    )

--- a/plans/static/plans/plan-persistence-fixes.js
+++ b/plans/static/plans/plan-persistence-fixes.js
@@ -1,0 +1,289 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$) {
+    return;
+  }
+
+  const VERSION = '2026.08.18.1';
+  const PIXELS_PER_MINUTE = 35 / 60;
+  const BASE_MINUTES = 6 * 60;
+  let recurringRequest = null;
+
+  function normalizeText(value) {
+    return String(value || '')
+      .trim()
+      .replace(/[\u200c\u200e\u200f\s]+/g, '')
+      .replace(/[يى]/g, 'ی')
+      .replace(/ك/g, 'ک');
+  }
+
+  function normalizeDay(value) {
+    const normalized = normalizeText(value);
+    const days = ['شنبه', 'یک‌شنبه', 'دوشنبه', 'سه‌شنبه', 'چهارشنبه', 'پنج‌شنبه', 'جمعه'];
+    return days.find(function (day) {
+      return normalizeText(day) === normalized;
+    }) || null;
+  }
+
+  function parseClock(value) {
+    if (!value) {
+      return null;
+    }
+    const raw = String(value);
+    if (raw.indexOf('T') >= 0 && window.moment) {
+      const parsed = window.moment.parseZone(raw);
+      if (parsed.isValid()) {
+        return parsed.hour() * 60 + parsed.minute();
+      }
+    }
+    const match = raw.match(/(\d{1,2}):(\d{2})/);
+    if (!match) {
+      return null;
+    }
+    return Number(match[1]) * 60 + Number(match[2]);
+  }
+
+  function clockFromTask($task) {
+    const top = Number.parseFloat($task.css('top')) || 0;
+    const height = Number.parseFloat($task.css('height')) || $task.outerHeight() || 0;
+    const start = BASE_MINUTES + Math.round(top / PIXELS_PER_MINUTE);
+    const duration = Math.max(15, Math.round(height / PIXELS_PER_MINUTE));
+    return {
+      start: start % (24 * 60),
+      end: (start + duration) % (24 * 60)
+    };
+  }
+
+  function taskTitle($task) {
+    const $title = $task.find('.task-title').first();
+    if ($title.is('input, textarea')) {
+      return String($title.val() || '').trim();
+    }
+    return String($title.text() || '').trim();
+  }
+
+  function synchronizeTitleElement(element) {
+    if (!element || element.nodeType !== 1) {
+      return;
+    }
+    if (element.matches('input.task-title')) {
+      element.setAttribute('value', element.value || '');
+    } else if (element.matches('textarea.task-title')) {
+      element.textContent = element.value || '';
+    }
+  }
+
+  function synchronizeTitlesForExport() {
+    document.querySelectorAll('.calendar-task .task-title').forEach(synchronizeTitleElement);
+    if (document.body) {
+      document.body.setAttribute('data-plan-export-title-sync-version', VERSION);
+    }
+  }
+
+  function sameRecurringEvent($task, event) {
+    if (($task.attr('data-box-type') || '') !== 'ایونت') {
+      return false;
+    }
+    if (normalizeText(taskTitle($task)) !== normalizeText(event.name)) {
+      return false;
+    }
+
+    const taskClock = clockFromTask($task);
+    const eventStart = parseClock(event.start_time);
+    const eventEnd = parseClock(event.end_time);
+    if (eventStart === null || eventEnd === null) {
+      return false;
+    }
+
+    return Math.abs(taskClock.start - eventStart) <= 1 && Math.abs(taskClock.end - eventEnd) <= 1;
+  }
+
+  function findDayContainer(dayName) {
+    const canonical = normalizeDay(dayName);
+    if (!canonical) {
+      return $();
+    }
+    return $('.calendar .day-column').filter(function () {
+      return normalizeDay($(this).attr('data-day')) === canonical;
+    }).find('.task-container').first();
+  }
+
+  function recurringEventAlreadyVisible(event) {
+    const $container = findDayContainer(event.day_of_week);
+    if (!$container.length) {
+      return false;
+    }
+    let found = false;
+    $container.children('.calendar-task').each(function () {
+      if (sameRecurringEvent($(this), event)) {
+        found = true;
+        return false;
+      }
+    });
+    return found;
+  }
+
+  function appendRecurringEvent(event) {
+    if (!event || !event.name || recurringEventAlreadyVisible(event)) {
+      return false;
+    }
+
+    const $container = findDayContainer(event.day_of_week);
+    if (!$container.length) {
+      return false;
+    }
+
+    const start = parseClock(event.start_time);
+    const end = parseClock(event.end_time);
+    if (start === null || end === null) {
+      return false;
+    }
+    let duration = end - start;
+    if (duration <= 0) {
+      duration += 24 * 60;
+    }
+    duration = Math.max(15, duration);
+
+    const top = typeof window.calculateTop === 'function'
+      ? window.calculateTop(event.start_time)
+      : Math.max(0, start - BASE_MINUTES) * PIXELS_PER_MINUTE;
+    const height = typeof window.calculateHeight === 'function'
+      ? window.calculateHeight(event.start_time, event.end_time)
+      : duration * PIXELS_PER_MINUTE;
+
+    const $task = $('<div class="calendar-task event-task"></div>')
+      .attr('data-box-type', 'ایونت')
+      .attr('data-duration-minutes', duration)
+      .attr('data-recurring-default', 'true')
+      .css({
+        top: top + 'px',
+        height: Math.max(15 * PIXELS_PER_MINUTE, height) + 'px',
+        left: '5%'
+      });
+
+    if (event.default_event_id) {
+      $task.attr('data-default-event-id', event.default_event_id);
+    }
+
+    $task.append('<button type="button" class="remove-btn" title="حذف">✖</button>');
+    $task.append('<button type="button" class="tick-btn" title="ایجاد تکلیف از ایونت">افزودن تکلیف</button>');
+    $task.append(
+      $('<input type="text" class="task-title task-inp editable">')
+        .val(event.name)
+        .attr('value', event.name)
+    );
+    $task.append('<div class="time-label"></div>');
+
+    $container.append($task);
+    if (typeof window.initCalendarTask === 'function') {
+      window.initCalendarTask($task);
+    }
+    if (typeof window.updateTimeLabel === 'function') {
+      window.updateTimeLabel($task);
+    }
+    return true;
+  }
+
+  function mergeRecurringEvents(events) {
+    let added = 0;
+    (Array.isArray(events) ? events : []).forEach(function (event) {
+      if (appendRecurringEvent(event)) {
+        added += 1;
+      }
+    });
+    if (document.body) {
+      document.body.setAttribute('data-plan-recurring-defaults-version', VERSION);
+    }
+    return added;
+  }
+
+  function reloadRecurringEvents() {
+    const state = window.planRuntimeState || {};
+    const studentId = state.studentId || $('#student-select').val();
+    if (!studentId || !state.loaded) {
+      return Promise.resolve(0);
+    }
+
+    if (recurringRequest && typeof recurringRequest.abort === 'function') {
+      recurringRequest.abort();
+    }
+
+    return new Promise(function (resolve) {
+      recurringRequest = $.ajax({
+        url: '/get_default_events/',
+        method: 'GET',
+        dataType: 'json',
+        data: { student_id: studentId }
+      })
+        .done(function (events) {
+          resolve(mergeRecurringEvents(events));
+        })
+        .fail(function (xhr, status) {
+          if (status !== 'abort') {
+            console.warn('Could not reload recurring Plan events.', xhr && xhr.responseText);
+          }
+          resolve(0);
+        })
+        .always(function () {
+          recurringRequest = null;
+        });
+    });
+  }
+
+  function bindExportTitleSync() {
+    ['download-week-output', 'download-all-pdf'].forEach(function (id) {
+      const element = document.getElementById(id);
+      if (element && !element.dataset.planTitleSyncBound) {
+        element.dataset.planTitleSyncBound = 'true';
+        element.addEventListener('click', synchronizeTitlesForExport, true);
+      }
+    });
+
+    $(document)
+      .off('input.planTitleSync change.planTitleSync', '.calendar-task .task-title')
+      .on('input.planTitleSync change.planTitleSync', '.calendar-task .task-title', function () {
+        synchronizeTitleElement(this);
+      });
+  }
+
+  function bindRecurringReload() {
+    $(document)
+      .off('ajaxComplete.planRecurringDefaults')
+      .on('ajaxComplete.planRecurringDefaults', function (_event, xhr, settings) {
+        const url = String((settings && settings.url) || '');
+        if (url.indexOf('/get-weekly-report-details/') === -1) {
+          return;
+        }
+
+        const response = (xhr && xhr.responseJSON) || null;
+        // The canonical runtime already loads recurring defaults for a completely
+        // empty week. We only need to repair the historical gap: a saved report
+        // with one or more tasks used to suppress every recurring class/event.
+        if (!response || !Array.isArray(response.tasks) || !response.tasks.length) {
+          return;
+        }
+        window.setTimeout(reloadRecurringEvents, 0);
+      });
+  }
+
+  function initialize() {
+    bindExportTitleSync();
+    bindRecurringReload();
+    synchronizeTitlesForExport();
+
+    window.planPersistenceFixes = {
+      version: VERSION,
+      synchronizeTitlesForExport: synchronizeTitlesForExport,
+      mergeRecurringEvents: mergeRecurringEvents,
+      reloadRecurringEvents: reloadRecurringEvents
+    };
+
+    if (document.body) {
+      document.body.setAttribute('data-plan-persistence-fixes-version', VERSION);
+    }
+    window.dispatchEvent(new CustomEvent('plan:persistence-fixes-ready'));
+  }
+
+  $(initialize);
+})(window, document, window.jQuery);

--- a/plans/test_plan_persistence.py
+++ b/plans/test_plan_persistence.py
@@ -1,0 +1,160 @@
+import datetime as dt
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from accounts.models import Student
+from plans.default_plan_data import ensure_advisor_for_user, seed_plan_defaults
+from plans.models import Box, BoxType, Lesson, LessonType, WeeklyReport, WeeklyReportDetail
+
+
+class PlanPersistenceRegressionTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.admin = User.objects.create_superuser(
+            username="plan-persistence-admin",
+            email="plan-persistence@example.com",
+            password="test-password",
+        )
+        self.advisor = ensure_advisor_for_user(self.admin)
+        seed_plan_defaults(advisor=self.advisor)
+        self.student = Student.objects.get(
+            profile__user__username="demo_plan_student_t"
+        )
+        self.client.force_login(self.admin)
+
+    def aware(self, year, month, day, hour=0, minute=0):
+        value = dt.datetime(year, month, day, hour, minute)
+        return timezone.make_aware(value, timezone.get_current_timezone())
+
+    def test_plan_page_loads_persistence_runtime(self):
+        response = self.client.get("/plan/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "/static/plans/plan-persistence-fixes.js?v=20260818-1")
+        self.assertContains(response, 'data-plan-persistence-fixes="true"')
+
+    def test_event_and_event_assignment_titles_round_trip_exactly(self):
+        payload = {
+            "student_id": self.student.pk,
+            "week_start": "2039-01-01",
+            "week_end": "2039-01-07",
+            "days": [
+                {
+                    "day": "شنبه",
+                    "disabled": False,
+                    "tasks": [
+                        {
+                            "title": "کلاس فیزیک دهم",
+                            "start": "10:00:00",
+                            "end": "11:30:00",
+                            "box_type": "ایونت",
+                        },
+                        {
+                            "title": "آمادگی و تکلیف کلاس فیزیک دهم",
+                            "start": "18:30:00",
+                            "end": "19:00:00",
+                            "box_type": "تکلیف",
+                        },
+                    ],
+                }
+            ],
+        }
+        save_response = self.client.post(
+            "/save-weekly-report/",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        self.assertEqual(save_response.status_code, 200, save_response.content)
+
+        report = WeeklyReport.objects.get(pk=save_response.json()["report_id"])
+        self.assertEqual(
+            set(report.details.values_list("box__name", flat=True)),
+            {"کلاس فیزیک دهم", "آمادگی و تکلیف کلاس فیزیک دهم"},
+        )
+
+        reload_response = self.client.get(
+            "/get-weekly-report-details/",
+            {"student_id": self.student.pk, "week_start": "2039-01-01"},
+        )
+        self.assertEqual(reload_response.status_code, 200, reload_response.content)
+        self.assertEqual(
+            {task["title"] for task in reload_response.json()["tasks"]},
+            {"کلاس فیزیک دهم", "آمادگی و تکلیف کلاس فیزیک دهم"},
+        )
+
+    def test_reuse_uses_latest_report_that_actually_contains_study(self):
+        lesson_type, _ = LessonType.objects.get_or_create(name="اختصاصی")
+        lesson = Lesson.objects.create(
+            subject_code="PERSIST-BIO-11",
+            name="زیست یازدهم تست پایداری",
+            lesson_type=lesson_type,
+            grade=self.student.grade,
+        )
+        study_type = BoxType.objects.get(name="مطالعه")
+        event_type = BoxType.objects.get(name="ایونت")
+
+        reusable_report = WeeklyReport.objects.create(
+            student=self.student,
+            week_start=self.aware(2039, 2, 5),
+            week_end=self.aware(2039, 2, 11, 23, 59),
+        )
+        study_box = Box.objects.create(
+            box_type=study_type,
+            lesson=lesson,
+            name=lesson.name,
+            duration_minutes=90,
+            optional_tests_count=25,
+            is_default=False,
+        )
+        WeeklyReportDetail.objects.create(
+            report=reusable_report,
+            box=study_box,
+            start_time=self.aware(2039, 2, 5, 16, 0),
+            end_time=self.aware(2039, 2, 5, 17, 30),
+            day_of_week="شنبه",
+        )
+
+        # This is newer, but it is only a class/event. The old implementation
+        # selected this report first and then returned an empty study list.
+        newer_event_report = WeeklyReport.objects.create(
+            student=self.student,
+            week_start=self.aware(2039, 2, 12),
+            week_end=self.aware(2039, 2, 18, 23, 59),
+        )
+        event_box = Box.objects.create(
+            box_type=event_type,
+            name="کلاس ثابت",
+            duration_minutes=60,
+            is_default=False,
+        )
+        WeeklyReportDetail.objects.create(
+            report=newer_event_report,
+            box=event_box,
+            start_time=self.aware(2039, 2, 12, 9, 0),
+            end_time=self.aware(2039, 2, 12, 10, 0),
+            day_of_week="شنبه",
+        )
+
+        # An even newer empty save must not hide the reusable plan either.
+        WeeklyReport.objects.create(
+            student=self.student,
+            week_start=self.aware(2039, 2, 19),
+            week_end=self.aware(2039, 2, 25, 23, 59),
+        )
+
+        response = self.client.get(
+            "/get-last-weekly-report/",
+            {"student_id": self.student.pk},
+        )
+        self.assertEqual(response.status_code, 200, response.content)
+        body = response.json()
+        self.assertEqual(body["report_id"], reusable_report.pk)
+        self.assertEqual(len(body["tasks"]), 1)
+        task = body["tasks"][0]
+        self.assertEqual(task["lesson_id"], lesson.pk)
+        self.assertEqual(task["lesson_name"], lesson.name)
+        self.assertEqual(task["duration_minutes"], 90)
+        self.assertEqual(task["optional_tests_count"], 25)
+        self.assertEqual(task["day_of_week"], "شنبه")

--- a/plans/urls.py
+++ b/plans/urls.py
@@ -8,6 +8,7 @@ from . import (
     dashboard_page,
     lesson_catalog,
     plan_page,
+    plan_reuse,
     weekly_plans,
     weekly_plans_v2,
 )
@@ -42,7 +43,7 @@ urlpatterns = [
     path("get_default_boxes/", lesson_catalog.get_default_boxes, name="get_default_boxes"),
     path("get_default_events/", lesson_catalog.get_default_events, name="get_default_events"),
     path("get-lessons-for-student/", lesson_catalog.get_lessons_for_student, name="get_lessons_for_student"),
-    path("get-last-weekly-report/", get_last_weekly_report, name="get_last_weekly_report"),
+    path("get-last-weekly-report/", plan_reuse.get_last_weekly_report, name="get_last_weekly_report"),
     path("dashboard/", dashboard_page.dashboard_view, name="dashboard"),
     path("api/admin-panel-data/", get_admin_panel_data, name="api_admin_panel_data"),
     path("api/add-student/", dashboard_admin.add_student_view, name="api_add_student"),


### PR DESCRIPTION
Fixes the three persistence regressions reported by advisors:

1. Event and event-derived assignment titles are synchronized from live input values into serialized HTML before the legacy PDF clone runs, so first-time exports no longer produce blank boxes.
2. Recurring DefaultEvent classes are merged into a saved week even when that week already contains study/tasks. Exact day/title/time matches are deduplicated, so a class already present in the saved report is not duplicated.
3. Saved-plan reuse now selects the newest report that actually contains study boxes instead of selecting a newer empty/event-only report and then returning no tasks. The endpoint also uses canonical student access validation and canonical day names.

Adds Django regression coverage plus a production Playwright test that reproduces the blank serialized title case and verifies recurring classes are merged alongside an existing saved task without mutating production data. Asset version is bumped to force browsers off the stale runtime.