### PR TITLE
Fix Plan repeat colors, PDF artifacts and long assignment titles

### DIFF
--- a/.github/workflows/validate-plan.yml
+++ b/.github/workflows/validate-plan.yml
@@ -40,6 +40,7 @@ jobs:
           node --check plans/static/plans/plan-runtime.js
           node --check plans/static/plans/plan-secondary.js
           node --check plans/static/plans/plan-persistence-fixes.js
+          node --check plans/static/plans/plan-output-polish.js
           node --check plans/static/plans/plan-time-grid.js
           node --check plans/static/plans/plan-interactions.js
           node --check plans/static/plans/plan-manual-resize.js
@@ -76,8 +77,10 @@ jobs:
           guard = source.index('plans/plan-performance-guard.js')
           runtime = source.index('plans/plan-runtime.js')
           persistence = source.index('plans/plan-persistence-fixes.js')
+          polish = source.index('plans/plan-output-polish.js')
           assert guard < runtime, 'performance guard must load before Plan runtime scripts'
           assert runtime < persistence, 'persistence fixes must load after canonical Plan runtime'
+          assert persistence < polish, 'output polish must load after persistence fixes'
           PY
 
       - name: Install Python dependencies

--- a/deploy/plan_persistence_e2e.py
+++ b/deploy/plan_persistence_e2e.py
@@ -44,6 +44,10 @@ def load_week(page) -> None:
         "window.planPersistenceFixes && window.planPersistenceFixes.version === '2026.08.18.1'",
         timeout=15_000,
     )
+    page.wait_for_function(
+        "window.planOutputPolish && window.planOutputPolish.version === '2026.08.19.1'",
+        timeout=15_000,
+    )
 
 
 def main() -> int:
@@ -123,6 +127,143 @@ def main() -> int:
         require(
             export_result["containsEvent"] and export_result["containsAssignment"],
             "serialized PDF calendar clone contains both visible titles",
+        )
+
+        filename_result = page.evaluate(
+            """
+            () => ({
+              fileName: window.planOutputPolish.studentPdfFileName(''),
+              summaryName: window.planOutputPolish.studentPdfFileName('خلاصه'),
+              rewritten: window.planOutputPolish.rewritePdfMarkup(
+                '<html><head><title>خروجی هفته</title></head><body><script>pdf.save("generic.pdf");<\\/script></body></html>',
+                window.planOutputPolish.studentPdfFileName(''),
+                window.jQuery('#student-select option:selected').text().trim()
+              )
+            })
+            """
+        )
+        require(
+            filename_result["fileName"] == f"{STUDENT_LABEL}.pdf",
+            "weekly PDF filename is the selected student's name",
+        )
+        require(
+            filename_result["summaryName"] == f"{STUDENT_LABEL}-خلاصه.pdf",
+            "summary PDF filename keeps the selected student's name",
+        )
+        require(
+            filename_result["fileName"] in filename_result["rewritten"],
+            "popup PDF save markup is rewritten to the student filename",
+        )
+
+        visual_result = page.evaluate(
+            """
+            () => {
+              const $ = window.jQuery;
+              const $container = $('.calendar .task-container').first();
+
+              const $study = $('<div class="calendar-task extended-task"></div>')
+                .attr('data-box-type', 'مطالعه')
+                .attr('data-lesson-id', '999991')
+                .attr('data-lesson-name', 'زیست')
+                .css({position: 'absolute', top: '620px', height: '70px', left: '5%', backgroundColor: 'rgb(123, 190, 94)'})
+                .append('<div class="task-title">زیست دهم</div>')
+                .append('<select class="task-chapter"><option value="1" selected>فصل ۳ - تبادلات</option></select>')
+                .append('<span class="select2-container" style="display:block;width:28px;height:58px;border:1px solid #111"></span>')
+                .append('<select class="task-extra"><option value="45" selected>45</option></select>')
+                .append('<div class="ui-resizable-handle ui-resizable-s" style="display:block;width:22px;height:54px;border:1px solid #222"></div>')
+                .append('<div class="time-label"></div>');
+              $container.append($study);
+
+              const cleanup = window.planOutputPolish.prepareExportUi();
+              const $clone = $('.calendar-wrapper').clone();
+              const hiddenArtifacts = $clone.find('[data-plan-export-hidden="true"]');
+              const artifactsStillDisplayed = hiddenArtifacts.filter(function () {
+                return String($(this).attr('style') || '').indexOf('display: none') === -1;
+              }).length;
+              const mirrorText = $clone.find('.plan-export-study-meta').last().text();
+              cleanup();
+
+              const $source = $('<div class="calendar-task extended-task"></div>')
+                .attr('data-box-type', 'مطالعه')
+                .attr('data-lesson-id', '999992')
+                .attr('data-lesson-name', 'زیست')
+                .css({position: 'absolute', top: '710px', height: '52.5px', left: '5%', backgroundColor: 'rgb(154, 205, 50)'})
+                .append('<button type="button" class="repeat-btn">تکرار</button>')
+                .append('<div class="task-title">زیست دهم</div>');
+              const $repeated = $('<div class="calendar-task extended-task"></div>')
+                .attr('data-box-type', 'مطالعه')
+                .attr('data-lesson-id', '999992')
+                .css({position: 'absolute', top: '710px', height: '52.5px', left: '5%', backgroundColor: 'rgb(227, 242, 253)'})
+                .append('<div class="task-title">زیست دهم</div>');
+              $container.append($source).append($repeated);
+              window.planOutputPolish.preserveRepeatedStudyColor($source.find('.repeat-btn')[0]);
+              const sourceColor = getComputedStyle($source[0]).backgroundColor;
+              const repeatedColor = getComputedStyle($repeated[0]).backgroundColor;
+
+              const longTitle = 'آمادگی و تکلیف مشاهده کلاس شیمی و مرور نکات جلسه قبل';
+              const $assignment = $('<div class="calendar-task"></div>')
+                .attr('data-box-type', 'تکلیف')
+                .css({position: 'absolute', top: '790px', height: '52.5px', left: '5%'})
+                .append($('<input type="text" class="task-title task-inp editable">').val(longTitle))
+                .append('<div class="time-label"></div>');
+              $container.append($assignment);
+              window.planOutputPolish.upgradeAssignmentTitles(document);
+              const assignmentTitle = $assignment.find('.task-title')[0];
+              const assignmentStyles = getComputedStyle(assignmentTitle);
+
+              const result = {
+                hiddenArtifacts: hiddenArtifacts.length,
+                artifactsStillDisplayed,
+                mirrorText,
+                sourceColor,
+                repeatedColor,
+                repeatedLessonName: $repeated.attr('data-lesson-name') || '',
+                assignmentTag: assignmentTitle.tagName,
+                assignmentValue: assignmentTitle.value || assignmentTitle.textContent || '',
+                assignmentWhiteSpace: assignmentStyles.whiteSpace,
+                assignmentOverflowWrap: assignmentStyles.overflowWrap,
+                assignmentFontSize: Number.parseFloat(assignmentStyles.fontSize) || 0
+              };
+
+              $study.remove();
+              $source.remove();
+              $repeated.remove();
+              $assignment.remove();
+              return result;
+            }
+            """
+        )
+        require(
+            visual_result["hiddenArtifacts"] >= 2 and visual_result["artifactsStillDisplayed"] == 0,
+            "Select2 and resize editor rectangles are hidden in the PDF clone",
+        )
+        require(
+            "فصل ۳ - تبادلات" in visual_result["mirrorText"] and "45 تست" in visual_result["mirrorText"],
+            "PDF clone keeps chapter and test text while hiding editor controls",
+        )
+        require(
+            visual_result["sourceColor"] == visual_result["repeatedColor"],
+            "repeated study boxes preserve the exact source color",
+        )
+        require(
+            visual_result["repeatedLessonName"] == "زیست",
+            "repeated study box recovers its lesson identity",
+        )
+        require(
+            visual_result["assignmentTag"] == "TEXTAREA",
+            "event-derived assignment title uses a wrapping multiline control",
+        )
+        require(
+            visual_result["assignmentValue"].startswith("آمادگی و تکلیف"),
+            "long assignment title remains intact after wrapping upgrade",
+        )
+        require(
+            visual_result["assignmentWhiteSpace"] in ("pre-wrap", "pre-wrap-auto"),
+            "assignment title is allowed to wrap inside the box",
+        )
+        require(
+            visual_result["assignmentFontSize"] <= 9.5,
+            "assignment title uses compact readable typography",
         )
 
         recurring_result = page.evaluate(

--- a/plans/plan_page.py
+++ b/plans/plan_page.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from plans import lesson_catalog
 
 
-ASSET_VERSION = "20260818-1"
+ASSET_VERSION = "20260819-1"
 STYLE_PATHS = (
     ("plans/plan-interactions.css", "data-plan-interactions-style"),
     ("plans/plan-time-grid.css", "data-plan-time-grid-style"),
@@ -15,6 +15,7 @@ STYLE_PATHS = (
     ("plans/plan-modern-ui-fixes.css", "data-plan-modern-ui-fixes-style"),
     ("plans/plan-start-state.css", "data-plan-start-state-style"),
     ("plans/plan-quarter-snap-feedback.css", "data-plan-quarter-snap-feedback-style"),
+    ("plans/plan-output-polish.css", "data-plan-output-polish-style"),
 )
 RUNTIME_PATHS = (
     ("plans/plan-performance-guard.js", "data-plan-performance-guard"),
@@ -32,6 +33,7 @@ RUNTIME_PATHS = (
     ("plans/plan-chapter-loader.js", "data-plan-chapter-loader"),
     ("plans/plan-quarter-snap-feedback.js", "data-plan-quarter-snap-feedback"),
     ("plans/plan-stability-fixes.js", "data-plan-stability-fixes"),
+    ("plans/plan-output-polish.js", "data-plan-output-polish"),
 )
 
 

--- a/plans/static/plans/plan-output-polish.css
+++ b/plans/static/plans/plan-output-polish.css
@@ -1,0 +1,44 @@
+.calendar .calendar-task.assignment-task,
+.calendar .calendar-task[data-box-type="تکلیف"] {
+  overflow: hidden;
+}
+
+.calendar .calendar-task.assignment-task .task-title,
+.calendar .calendar-task[data-box-type="تکلیف"] .task-title {
+  width: calc(100% - 8px) !important;
+  max-width: calc(100% - 8px) !important;
+  height: calc(100% - 20px) !important;
+  min-height: 26px !important;
+  margin: 2px 4px 0 !important;
+  padding: 2px 4px !important;
+  box-sizing: border-box !important;
+  overflow: hidden !important;
+  white-space: pre-wrap !important;
+  overflow-wrap: anywhere !important;
+  word-break: break-word !important;
+  resize: none !important;
+  color: #172033 !important;
+  font-size: 9px !important;
+  font-weight: 800 !important;
+  line-height: 1.25 !important;
+  text-align: right !important;
+  border: 0 !important;
+  border-radius: 5px !important;
+  outline: none !important;
+  background: rgba(255, 255, 255, .30) !important;
+  box-shadow: none !important;
+}
+
+.calendar .calendar-task.assignment-task .task-title:focus,
+.calendar .calendar-task[data-box-type="تکلیف"] .task-title:focus {
+  background: rgba(255, 255, 255, .58) !important;
+}
+
+.calendar .calendar-task.assignment-task .time-label,
+.calendar .calendar-task[data-box-type="تکلیف"] .time-label {
+  z-index: 2;
+}
+
+.calendar .calendar-task [data-plan-export-hidden="true"] {
+  display: none !important;
+}

--- a/plans/static/plans/plan-output-polish.js
+++ b/plans/static/plans/plan-output-polish.js
@@ -1,0 +1,418 @@
+(function (window, document, $) {
+  'use strict';
+
+  if (!$) {
+    return;
+  }
+
+  const VERSION = '2026.08.19.1';
+  const EXPORT_HIDE_SELECTOR = [
+    '.calendar-task .select2-container',
+    '.calendar-task .ui-resizable-handle',
+    '.calendar-task .plan-resize-handle',
+    '.calendar-task select.task-chapter',
+    '.calendar-task select.task-extra'
+  ].join(',');
+
+  function normalizeText(value) {
+    return String(value || '')
+      .trim()
+      .replace(/[\u200c\u200e\u200f\s]+/g, '')
+      .replace(/[يى]/g, 'ی')
+      .replace(/ك/g, 'ک');
+  }
+
+  function selectedStudentName() {
+    return String($('#student-select option:selected').text() || '')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  function safeFileStem(value) {
+    const cleaned = String(value || '')
+      .replace(/[\\/:*?"<>|]+/g, '-')
+      .replace(/\s+/g, ' ')
+      .replace(/[. ]+$/g, '')
+      .trim();
+    return cleaned || 'دانش‌آموز';
+  }
+
+  function studentPdfFileName(suffix) {
+    const student = safeFileStem(selectedStudentName());
+    const tail = String(suffix || '').trim();
+    return tail ? student + '-' + tail + '.pdf' : student + '.pdf';
+  }
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function rewritePdfMarkup(markup, filename, title) {
+    if (typeof markup !== 'string') {
+      return markup;
+    }
+    const fileLiteral = JSON.stringify(filename);
+    let rewritten = markup.replace(
+      /pdf\.save\((?:'[^']*'|"[^"]*")\);/,
+      'pdf.save(' + fileLiteral + ');'
+    );
+    if (title) {
+      rewritten = rewritten.replace(
+        /<title>(?:خروجی هفته|خلاصه هفته)<\/title>/,
+        '<title>' + escapeHtml(title) + '</title>'
+      );
+    }
+    return rewritten;
+  }
+
+  function interceptNextPopupPdf(filename, title) {
+    const originalOpen = window.open;
+    if (typeof originalOpen !== 'function') {
+      return function () {};
+    }
+
+    let restored = false;
+    function restore() {
+      if (restored) {
+        return;
+      }
+      restored = true;
+      if (window.open === wrappedOpen) {
+        window.open = originalOpen;
+      }
+    }
+
+    function wrappedOpen() {
+      const popup = originalOpen.apply(window, arguments);
+      if (!popup || !popup.document || typeof popup.document.write !== 'function') {
+        return popup;
+      }
+
+      const originalWrite = popup.document.write.bind(popup.document);
+      popup.document.write = function (markup) {
+        return originalWrite(rewritePdfMarkup(markup, filename, title));
+      };
+      return popup;
+    }
+
+    window.open = wrappedOpen;
+    window.setTimeout(restore, 0);
+    return restore;
+  }
+
+  function taskTitle($task) {
+    const $title = $task.find('.task-title').first();
+    if ($title.is('input, textarea')) {
+      return String($title.val() || '').trim();
+    }
+    return String($title.text() || '').trim();
+  }
+
+  function paletteLessonForTask($task) {
+    const lessonId = String($task.attr('data-lesson-id') || '').trim();
+    if (!lessonId) {
+      return $();
+    }
+    return $('.subjects-box .task[data-lesson-id]').filter(function () {
+      return String($(this).attr('data-lesson-id') || '') === lessonId;
+    }).first();
+  }
+
+  function repairStudyTaskColor($task, preferredColor) {
+    if (!$task || !$task.length || ($task.attr('data-box-type') || '') !== 'مطالعه') {
+      return false;
+    }
+
+    const $palette = paletteLessonForTask($task);
+    let lessonName = String($task.attr('data-lesson-name') || '').trim();
+    if (!lessonName && $palette.length) {
+      lessonName = String($palette.attr('data-lesson-name') || '').trim();
+      if (lessonName) {
+        $task.attr('data-lesson-name', lessonName);
+      }
+    }
+
+    let color = String(preferredColor || '').trim();
+    if (!color && lessonName && window.subjectColors && window.subjectColors[lessonName]) {
+      color = window.subjectColors[lessonName];
+    }
+    if (!color && $palette.length && $palette[0]) {
+      color = window.getComputedStyle($palette[0]).backgroundColor || '';
+    }
+    if (!color || color === 'rgba(0, 0, 0, 0)' || color === 'transparent') {
+      return false;
+    }
+
+    $task.css('background-color', color);
+    $task.attr('data-plan-study-color', color);
+    return true;
+  }
+
+  function repairAllStudyTaskColors() {
+    $('.calendar .calendar-task[data-box-type="مطالعه"]').each(function () {
+      repairStudyTaskColor($(this));
+    });
+  }
+
+  function preserveRepeatedStudyColor(button) {
+    const $source = $(button).closest('.calendar-task');
+    if (!$source.length || ($source.attr('data-box-type') || '') !== 'مطالعه') {
+      return;
+    }
+
+    const lessonId = String($source.attr('data-lesson-id') || '').trim();
+    const sourceColor = window.getComputedStyle($source[0]).backgroundColor || '';
+    const sourceTitle = normalizeText(taskTitle($source));
+
+    $('.calendar .calendar-task[data-box-type="مطالعه"]').each(function () {
+      const $candidate = $(this);
+      const sameLessonId = lessonId && String($candidate.attr('data-lesson-id') || '') === lessonId;
+      const sameTitle = !lessonId && sourceTitle && normalizeText(taskTitle($candidate)) === sourceTitle;
+      if (sameLessonId || sameTitle || this === $source[0]) {
+        repairStudyTaskColor($candidate, sourceColor);
+      }
+    });
+  }
+
+  function styleAssignmentTitle($title) {
+    $title
+      .attr('data-plan-assignment-title', 'true')
+      .css({
+        width: 'calc(100% - 8px)',
+        maxWidth: 'calc(100% - 8px)',
+        height: 'calc(100% - 20px)',
+        minHeight: '26px',
+        margin: '2px 4px 0',
+        padding: '2px 4px',
+        border: '0',
+        borderRadius: '5px',
+        background: 'rgba(255,255,255,.30)',
+        color: '#172033',
+        fontSize: '9px',
+        fontWeight: '800',
+        lineHeight: '1.25',
+        textAlign: 'right',
+        whiteSpace: 'pre-wrap',
+        overflowWrap: 'anywhere',
+        wordBreak: 'break-word',
+        resize: 'none',
+        overflow: 'hidden',
+        boxSizing: 'border-box'
+      });
+  }
+
+  function upgradeAssignmentTask($task) {
+    if (!$task || !$task.length) {
+      return false;
+    }
+    const type = String($task.attr('data-box-type') || '');
+    if (type !== 'تکلیف') {
+      return false;
+    }
+    $task.addClass('assignment-task');
+
+    let $title = $task.find('.task-title').first();
+    if (!$title.length) {
+      return false;
+    }
+
+    if ($title.is('input')) {
+      const value = String($title.val() || '');
+      const className = $title.attr('class') || 'task-title task-inp editable';
+      const placeholder = $title.attr('placeholder') || 'عنوان تکلیف';
+      const $textarea = $('<textarea rows="2"></textarea>')
+        .attr('class', className)
+        .attr('placeholder', placeholder)
+        .attr('aria-label', 'عنوان تکلیف')
+        .val(value)
+        .text(value);
+      $title.replaceWith($textarea);
+      $title = $textarea;
+    }
+
+    styleAssignmentTitle($title);
+    return true;
+  }
+
+  function upgradeAssignmentTitles(root) {
+    const $root = root ? $(root) : $(document);
+    let changed = 0;
+    $root.find('.calendar-task[data-box-type="تکلیف"], .calendar-task.assignment-task').each(function () {
+      if (upgradeAssignmentTask($(this))) {
+        changed += 1;
+      }
+    });
+    return changed;
+  }
+
+  function selectedChapterText($task) {
+    const $select = $task.find('select.task-chapter').first();
+    let value = String($select.find('option:selected').text() || '').trim();
+    if (!value || value === '-' || /شماره فصل/.test(value)) {
+      value = String($task.find('.chapter-display').first().text() || '').trim();
+    }
+    if (!value || value === '-' || /شماره فصل/.test(value)) {
+      value = String($task.find('.select2-selection__rendered').first().attr('title') || '').trim();
+    }
+    return value && value !== '-' && !/شماره فصل/.test(value) ? value : '';
+  }
+
+  function selectedTestsText($task) {
+    const raw = String($task.find('select.task-extra').first().val() || '').trim();
+    if (raw && raw !== '0') {
+      return raw + ' تست';
+    }
+    const display = String($task.find('.tests-display').first().text() || '').trim();
+    return display && display !== '-' ? display : '';
+  }
+
+  function addExportStudyMirrors() {
+    $('.calendar .calendar-task[data-box-type="مطالعه"]').each(function () {
+      const $task = $(this);
+      $task.children('.plan-export-study-meta').remove();
+      const chapter = selectedChapterText($task);
+      const tests = selectedTestsText($task);
+      if (!chapter && !tests) {
+        return;
+      }
+      const parts = [];
+      if (chapter) {
+        parts.push(chapter);
+      }
+      if (tests) {
+        parts.push(tests);
+      }
+      const $meta = $('<div class="plan-export-study-meta"></div>')
+        .text(parts.join(' | '))
+        .css({
+          position: 'absolute',
+          right: '5px',
+          left: '5px',
+          bottom: '12px',
+          overflow: 'hidden',
+          color: '#263238',
+          fontSize: '7px',
+          fontWeight: '700',
+          lineHeight: '1.2',
+          textAlign: 'right',
+          whiteSpace: 'normal'
+        });
+      $task.append($meta);
+    });
+  }
+
+  function prepareExportUi() {
+    const savedStyles = [];
+    document.querySelectorAll(EXPORT_HIDE_SELECTOR).forEach(function (element) {
+      savedStyles.push([element, element.getAttribute('style')]);
+      element.style.setProperty('display', 'none', 'important');
+      element.setAttribute('data-plan-export-hidden', 'true');
+    });
+
+    addExportStudyMirrors();
+    upgradeAssignmentTitles(document);
+    if (window.planPersistenceFixes && typeof window.planPersistenceFixes.synchronizeTitlesForExport === 'function') {
+      window.planPersistenceFixes.synchronizeTitlesForExport();
+    }
+
+    if (document.body) {
+      document.body.setAttribute('data-plan-export-polish-version', VERSION);
+    }
+
+    return function cleanupExportUi() {
+      savedStyles.forEach(function (entry) {
+        const element = entry[0];
+        const style = entry[1];
+        element.removeAttribute('data-plan-export-hidden');
+        if (style === null) {
+          element.removeAttribute('style');
+        } else {
+          element.setAttribute('style', style);
+        }
+      });
+      $('.calendar .plan-export-study-meta').remove();
+    };
+  }
+
+  function bindPdfExport(id, suffix) {
+    const element = document.getElementById(id);
+    if (!element || element.dataset.planOutputPolishBound) {
+      return;
+    }
+    element.dataset.planOutputPolishBound = 'true';
+    element.addEventListener('click', function () {
+      const student = selectedStudentName();
+      const cleanup = prepareExportUi();
+      interceptNextPopupPdf(studentPdfFileName(suffix), student);
+      window.setTimeout(cleanup, 0);
+    }, true);
+  }
+
+  function bindRepeatColorRepair() {
+    $(document)
+      .off('click.planOutputPolishRepeat', '.repeat-btn')
+      .on('click.planOutputPolishRepeat', '.repeat-btn', function () {
+        // The canonical runtime registered its delegated handler before this file,
+        // so its clones already exist by the time this handler runs.
+        preserveRepeatedStudyColor(this);
+      });
+  }
+
+  function observeCalendar() {
+    const calendar = document.querySelector('.calendar');
+    if (!calendar || calendar.dataset.planOutputPolishObserved) {
+      return;
+    }
+    calendar.dataset.planOutputPolishObserved = 'true';
+    const observer = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        mutation.addedNodes.forEach(function (node) {
+          if (!node || node.nodeType !== 1) {
+            return;
+          }
+          const $node = $(node);
+          if ($node.hasClass('calendar-task')) {
+            upgradeAssignmentTask($node);
+            repairStudyTaskColor($node);
+          }
+          upgradeAssignmentTitles(node);
+          $node.find('.calendar-task[data-box-type="مطالعه"]').each(function () {
+            repairStudyTaskColor($(this));
+          });
+        });
+      });
+    });
+    observer.observe(calendar, { childList: true, subtree: true });
+  }
+
+  function initialize() {
+    upgradeAssignmentTitles(document);
+    repairAllStudyTaskColors();
+    bindRepeatColorRepair();
+    bindPdfExport('download-week-output', '');
+    bindPdfExport('download-week-summary', 'خلاصه');
+    observeCalendar();
+
+    window.planOutputPolish = {
+      version: VERSION,
+      studentPdfFileName: studentPdfFileName,
+      rewritePdfMarkup: rewritePdfMarkup,
+      prepareExportUi: prepareExportUi,
+      upgradeAssignmentTitles: upgradeAssignmentTitles,
+      repairStudyTaskColor: repairStudyTaskColor,
+      preserveRepeatedStudyColor: preserveRepeatedStudyColor
+    };
+
+    if (document.body) {
+      document.body.setAttribute('data-plan-output-polish-version', VERSION);
+    }
+    window.dispatchEvent(new CustomEvent('plan:output-polish-ready'));
+  }
+
+  $(initialize);
+})(window, document, window.jQuery);

--- a/plans/test_plan_persistence.py
+++ b/plans/test_plan_persistence.py
@@ -32,7 +32,7 @@ class PlanPersistenceRegressionTests(TestCase):
     def test_plan_page_loads_persistence_runtime(self):
         response = self.client.get("/plan/")
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "/static/plans/plan-persistence-fixes.js?v=20260818-1")
+        self.assertContains(response, "/static/plans/plan-persistence-fixes.js?v=20260819-1")
         self.assertContains(response, 'data-plan-persistence-fixes="true"')
 
     def test_event_and_event_assignment_titles_round_trip_exactly(self):


### PR DESCRIPTION
Fixes the four Plan presentation issues reported by advisors:

1. Repeated study boxes keep the exact background color of the source lesson instead of falling back to blue.
2. Weekly PDF export hides Select2/resizer editor controls before the legacy clone is created, preventing the white rectangle artifacts seen inside study boxes. Selected chapter/test text is mirrored as plain text for the PDF.
3. Weekly PDF filenames are rewritten to the selected student's name; summary PDFs keep the student name plus a short suffix.
4. Event-derived assignments use a wrapping multiline title control with compact typography so long `آمادگی و تکلیف ...` text remains visible inside the box.

Also bumps the Plan asset version and extends the production persistence Playwright regression with filename, PDF artifact, repeated-color and assignment-wrapping checks.